### PR TITLE
feat(ml): config-driven training pipeline with model persistence (#10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev run api web deploy-prep clean lint format test jupyter streamlit
+.PHONY: help install dev run api web deploy-prep clean lint format test jupyter streamlit train
 
 # Default target
 help:
@@ -17,6 +17,9 @@ help:
 	@echo "🧪 Data Management:"
 	@echo "  update-lines  Update market lines for current week"
 	@echo "  verify-db     Verify database tables exist"
+	@echo ""
+	@echo "🤖 ML:"
+	@echo "  train         Train the spread model (ARGS=\"--seasons 2023 2024\")"
 	@echo ""
 	@echo "🧹 Maintenance:"
 	@echo "  clean         Clean up generated files"
@@ -67,6 +70,11 @@ verify-db:
 verify-db-test:
 	@echo "🧪 Testing database operations..."
 	uv run python scripts/verify_tables.py --test
+
+# ML
+train:
+	@echo "🏋️  Training spread model..."
+	uv run python -m g_nfl.ml.train $(ARGS)
 
 # Maintenance
 clean:

--- a/configs/spread_params.yaml
+++ b/configs/spread_params.yaml
@@ -1,0 +1,15 @@
+# Hyperparameter overrides for the spread model (g_nfl.ml.train --config).
+# Anything set here is merged over g_nfl.ml.models.spread.DEFAULT_PARAMS,
+# which holds the notebook 01/02 baseline:
+#
+# n_estimators: 500
+# learning_rate: 0.05
+# max_depth: 4
+# min_child_weight: 3
+# subsample: 0.8
+# colsample_bytree: 0.8
+# colsample_bylevel: 0.8
+# reg_alpha: 0.1
+# reg_lambda: 1.0
+# random_state: 42
+{}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,11 @@ analysis = [
     "tqdm>=4.66.5,<5",
     "adjusttext>=1.2.0,<2",
     "statsmodels>=0.14.2,<0.15",
-    "xgboost>=2.1.1,<3",
+    "xgboost>=3.0.0,<4",
     "joblib>=1.4.2,<2",
     "lxml>=5.3.0,<6",
     "polars>=1.41.2",
+    "pyyaml>=6",
 ]
 
 [tool.uv]

--- a/src/g_nfl/ml/models/__init__.py
+++ b/src/g_nfl/ml/models/__init__.py
@@ -1,3 +1,6 @@
-"""Model wrappers. Implemented in #10 (spread: XGBoost regressor on
-home margin, hyperparameters supplied via config).
-"""
+"""Model wrappers (spread: XGBoost regressor on home margin,
+hyperparameters supplied via config)."""
+
+from g_nfl.ml.models.spread import SpreadModel, load_artifact, save_artifact
+
+__all__ = ["SpreadModel", "load_artifact", "save_artifact"]

--- a/src/g_nfl/ml/models/spread.py
+++ b/src/g_nfl/ml/models/spread.py
@@ -1,0 +1,70 @@
+"""XGBoost spread model: regresses home margin (schedule ``result``).
+
+Hyperparameters come from a config dict merged over DEFAULT_PARAMS —
+nothing tuned in code. Artifacts are a directory with the native
+xgboost model file plus a metadata json; the save path is pluggable so
+MLflow artifact logging (#12) can point it anywhere.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xgboost as xgb
+
+# notebook 01/02 hyperparameters
+DEFAULT_PARAMS: dict[str, Any] = {
+    "n_estimators": 500,
+    "learning_rate": 0.05,
+    "max_depth": 4,
+    "min_child_weight": 3,
+    "subsample": 0.8,
+    "colsample_bytree": 0.8,
+    "colsample_bylevel": 0.8,
+    "reg_alpha": 0.1,
+    "reg_lambda": 1.0,
+    "random_state": 42,
+}
+
+MODEL_FILENAME = "model.ubj"
+METADATA_FILENAME = "metadata.json"
+
+
+class SpreadModel:
+    """Thin XGBRegressor wrapper with config-driven hyperparameters."""
+
+    def __init__(self, params: dict[str, Any] | None = None):
+        self.params = {**DEFAULT_PARAMS, **(params or {})}
+        self._model = xgb.XGBRegressor(**self.params)
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> "SpreadModel":
+        self._model.fit(X, y)
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self._model.predict(X)
+
+    @property
+    def feature_importances_(self) -> np.ndarray:
+        return self._model.feature_importances_
+
+
+def save_artifact(
+    model: SpreadModel, metadata: dict[str, Any], artifact_dir: Path | str
+) -> Path:
+    """Write the model + metadata into ``artifact_dir``; returns the dir."""
+    artifact_dir = Path(artifact_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    model._model.save_model(artifact_dir / MODEL_FILENAME)
+    (artifact_dir / METADATA_FILENAME).write_text(json.dumps(metadata, indent=2))
+    return artifact_dir
+
+
+def load_artifact(artifact_dir: Path | str) -> tuple[SpreadModel, dict[str, Any]]:
+    """Load a saved model + its metadata from an artifact directory."""
+    artifact_dir = Path(artifact_dir)
+    metadata = json.loads((artifact_dir / METADATA_FILENAME).read_text())
+    model = SpreadModel(metadata.get("params"))
+    model._model.load_model(artifact_dir / MODEL_FILENAME)
+    return model, metadata

--- a/src/g_nfl/ml/train.py
+++ b/src/g_nfl/ml/train.py
@@ -1,4 +1,111 @@
-"""Training entrypoint: build matrix, train, persist model + metadata.
+"""Training entrypoint: build the game matrix, train, persist the model.
 
-Implemented in #10; MLflow logging added in #12.
+Run via ``make train`` or directly:
+
+    uv run python -m g_nfl.ml.train --seasons 2022 2023 --config configs/spread_params.yaml
+
+MLflow tracking arrives in #12; walk-forward evaluation in #11.
 """
+
+import argparse
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import yaml
+
+from g_nfl.ml.data import DEFAULT_CACHE_DIR, load_pbp, load_schedule
+from g_nfl.ml.features import build_features
+from g_nfl.ml.features.registry import get_feature_set
+from g_nfl.ml.features.windows import DEFAULT_ROLLING_WEEKS
+from g_nfl.ml.models.spread import DEFAULT_PARAMS, SpreadModel, save_artifact
+
+# drop early-season games where windowed stats are still thin (notebook used 4)
+DEFAULT_MIN_WEEK = 4
+# notebook training seasons
+DEFAULT_SEASONS = [2018, 2019, 2022, 2023, 2024, 2025]
+DEFAULT_OUTPUT_DIR = Path(__file__).parents[3] / "data" / "ml_models"
+
+
+def load_params_config(path: Path | str) -> dict[str, Any]:
+    """Hyperparameter overrides from a yaml (or json) file, merged over
+    DEFAULT_PARAMS."""
+    with open(path) as f:
+        overrides = yaml.safe_load(f) or {}
+    return {**DEFAULT_PARAMS, **overrides}
+
+
+def train(
+    seasons: list[int],
+    feature_set: str = "v1_team",
+    params: dict[str, Any] | None = None,
+    *,
+    min_week: int = DEFAULT_MIN_WEEK,
+    rolling_weeks: int = DEFAULT_ROLLING_WEEKS,
+    output_dir: Path | str = DEFAULT_OUTPUT_DIR,
+    cache_dir: Path | str = DEFAULT_CACHE_DIR,
+    refresh: bool = False,
+) -> Path:
+    """Train the spread model on completed games; returns the artifact dir."""
+    pbp = load_pbp(seasons, cache_dir=cache_dir, refresh=refresh)
+    schedule = load_schedule(seasons, cache_dir=cache_dir, refresh=refresh)
+
+    matrix = build_features(
+        pbp, schedule, rolling_weeks=rolling_weeks, min_week=min_week
+    ).filter(pl.col("result").is_not_null())
+
+    fs = get_feature_set(feature_set)
+    feature_cols = fs.columns(matrix)
+    X = matrix.select(feature_cols).to_numpy()
+    y = matrix["result"].to_numpy()
+
+    model = SpreadModel(params)
+    model.fit(X, y)
+
+    trained_at = datetime.now(UTC)
+    metadata = {
+        "model": "spread_xgb",
+        "feature_set": fs.name,
+        "feature_cols": feature_cols,
+        "seasons": list(seasons),
+        "params": model.params,
+        "rolling_weeks": rolling_weeks,
+        "min_week": min_week,
+        "n_games": matrix.height,
+        "trained_at": trained_at.isoformat(),
+    }
+    artifact_dir = Path(output_dir) / f"spread_{fs.name}_{trained_at:%Y%m%d_%H%M%S}"
+    return save_artifact(model, metadata, artifact_dir)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Train the spread model")
+    parser.add_argument("--seasons", type=int, nargs="+", default=DEFAULT_SEASONS)
+    parser.add_argument("--feature-set", default="v1_team")
+    parser.add_argument(
+        "--config", type=Path, help="yaml/json file with hyperparameter overrides"
+    )
+    parser.add_argument("--min-week", type=int, default=DEFAULT_MIN_WEEK)
+    parser.add_argument("--rolling-weeks", type=int, default=DEFAULT_ROLLING_WEEKS)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--refresh", action="store_true", help="refetch source data, ignore cache"
+    )
+    args = parser.parse_args(argv)
+
+    params = load_params_config(args.config) if args.config else None
+    artifact_dir = train(
+        args.seasons,
+        args.feature_set,
+        params,
+        min_week=args.min_week,
+        rolling_weeks=args.rolling_weeks,
+        output_dir=args.output_dir,
+        refresh=args.refresh,
+    )
+    print(f"saved model artifact to {artifact_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ml_train.py
+++ b/tests/test_ml_train.py
@@ -1,0 +1,101 @@
+"""Tests for the training pipeline (#10): config loading, training on the
+fixture data, and artifact persistence round-trips."""
+
+import json
+
+import numpy as np
+import polars as pl
+import pytest
+
+from g_nfl.ml import train as train_mod
+from g_nfl.ml.features import build_features
+from g_nfl.ml.models.spread import (
+    DEFAULT_PARAMS,
+    SpreadModel,
+    load_artifact,
+    save_artifact,
+)
+
+# tiny model so fixture-sized training stays fast
+SMALL_PARAMS = {"n_estimators": 10, "max_depth": 2}
+
+
+@pytest.fixture
+def stub_loaders(monkeypatch, pbp_sample: pl.DataFrame, schedule_sample: pl.DataFrame):
+    monkeypatch.setattr(train_mod, "load_pbp", lambda seasons, **kw: pbp_sample)
+    monkeypatch.setattr(
+        train_mod, "load_schedule", lambda seasons, **kw: schedule_sample
+    )
+
+
+def test_spread_model_params_merge_over_defaults():
+    model = SpreadModel(SMALL_PARAMS)
+    assert model.params["n_estimators"] == 10
+    assert model.params["learning_rate"] == DEFAULT_PARAMS["learning_rate"]
+
+
+def test_load_params_config(tmp_path):
+    cfg = tmp_path / "params.yaml"
+    cfg.write_text("n_estimators: 25\nmax_depth: 3\n")
+    params = train_mod.load_params_config(cfg)
+    assert params["n_estimators"] == 25
+    assert params["max_depth"] == 3
+    assert params["subsample"] == DEFAULT_PARAMS["subsample"]
+
+
+def test_artifact_round_trip(tmp_path):
+    rng = np.random.default_rng(0)
+    X, y = rng.normal(size=(40, 3)), rng.normal(size=40)
+    model = SpreadModel(SMALL_PARAMS).fit(X, y)
+
+    artifact_dir = save_artifact(model, {"params": model.params}, tmp_path / "m")
+    loaded, metadata = load_artifact(artifact_dir)
+
+    assert metadata["params"]["n_estimators"] == 10
+    np.testing.assert_allclose(loaded.predict(X), model.predict(X))
+
+
+def test_train_produces_loadable_model(
+    tmp_path, stub_loaders, pbp_sample: pl.DataFrame, schedule_sample: pl.DataFrame
+):
+    artifact_dir = train_mod.train([2023], params=SMALL_PARAMS, output_dir=tmp_path)
+    assert artifact_dir.parent == tmp_path
+
+    metadata = json.loads((artifact_dir / "metadata.json").read_text())
+    assert metadata["feature_set"] == "v1_team"
+    assert metadata["seasons"] == [2023]
+    assert metadata["params"]["n_estimators"] == 10
+    assert metadata["min_week"] == train_mod.DEFAULT_MIN_WEEK
+    # fixture has results for all games, so n_games = games from min_week on
+    expected_games = schedule_sample.filter(
+        pl.col("week") >= train_mod.DEFAULT_MIN_WEEK
+    ).height
+    assert metadata["n_games"] == expected_games
+
+    model, meta = load_artifact(artifact_dir)
+    matrix = build_features(
+        pbp_sample, schedule_sample, min_week=train_mod.DEFAULT_MIN_WEEK
+    )
+    preds = model.predict(matrix.select(meta["feature_cols"]).to_numpy())
+    assert preds.shape == (matrix.height,)
+    assert np.isfinite(preds).all()
+
+
+def test_cli_main(tmp_path, stub_loaders, capsys):
+    cfg = tmp_path / "params.yaml"
+    cfg.write_text("n_estimators: 5\nmax_depth: 2\n")
+    train_mod.main(
+        [
+            "--seasons",
+            "2023",
+            "--output-dir",
+            str(tmp_path / "models"),
+            "--config",
+            str(cfg),
+        ]
+    )
+    artifacts = list((tmp_path / "models").iterdir())
+    assert len(artifacts) == 1
+    metadata = json.loads((artifacts[0] / "metadata.json").read_text())
+    assert metadata["params"]["n_estimators"] == 5
+    assert str(artifacts[0]) in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -717,6 +717,7 @@ analysis = [
     { name = "nflreadpy" },
     { name = "plotly" },
     { name = "polars" },
+    { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "selenium" },
     { name = "statsmodels" },
@@ -758,11 +759,12 @@ analysis = [
     { name = "nflreadpy", specifier = ">=0.1.4,<0.2" },
     { name = "plotly", specifier = ">=5.22.0,<6" },
     { name = "polars", specifier = ">=1.41.2" },
+    { name = "pyyaml", specifier = ">=6" },
     { name = "scikit-learn", specifier = ">=1.5.1,<2" },
     { name = "selenium", specifier = ">=4.22.0,<5" },
     { name = "statsmodels", specifier = ">=0.14.2,<0.15" },
     { name = "tqdm", specifier = ">=4.66.5,<5" },
-    { name = "xgboost", specifier = ">=2.1.1,<3" },
+    { name = "xgboost", specifier = ">=3.0.0,<4" },
 ]
 dev = [
     { name = "pre-commit", specifier = ">=3.7.1,<4" },
@@ -3363,22 +3365,20 @@ wheels = [
 
 [[package]]
 name = "xgboost"
-version = "2.1.4"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/5e/860a1ef13ce38db8c257c83e138be64bcffde8f401e84bf1e2e91838afa3/xgboost-2.1.4.tar.gz", hash = "sha256:ab84c4bbedd7fae1a26f61e9dd7897421d5b08454b51c6eb072abc1d346d08d7", size = 1091127, upload-time = "2025-02-06T18:18:20.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/fe/7a1d2342c2e93f22b41515e02b73504c7809247b16ae395bd2ee7ef11e19/xgboost-2.1.4-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl", hash = "sha256:78d88da184562deff25c820d943420342014dd55e0f4c017cc4563c2148df5ee", size = 2140692, upload-time = "2025-02-06T18:16:59.23Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/b6/653a70910739f127adffbefb688ebc22b51139292757de7c22b1e04ce792/xgboost-2.1.4-py3-none-macosx_12_0_arm64.whl", hash = "sha256:523db01d4e74b05c61a985028bde88a4dd380eadc97209310621996d7d5d14a7", size = 1939418, upload-time = "2025-02-06T18:17:02.494Z" },
-    { url = "https://files.pythonhosted.org/packages/43/06/905fee34c10fb0d0c3baa15106413b76f360d8e958765ec57c9eddf762fa/xgboost-2.1.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:57c7e98111aceef4b689d7d2ce738564a1f7fe44237136837a47847b8b33bade", size = 4442052, upload-time = "2025-02-06T18:17:04.029Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/6a/41956f91ab984f2fa44529b2551d825a20d33807eba051a60d06ede2a87c/xgboost-2.1.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1343a512e634822eab30d300bfc00bf777dc869d881cc74854b42173cfcdb14", size = 4533170, upload-time = "2025-02-06T18:17:05.753Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/53/37032dca20dae7a88ad1907f817a81f232ca6e935f0c28c98db3c0a0bd22/xgboost-2.1.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d366097d0db047315736f46af852feaa907f6d7371716af741cdce488ae36d20", size = 4206715, upload-time = "2025-02-06T18:17:08.448Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3c/e3a93bfa7e8693c825df5ec02a40f7ff5f0950e02198b1e85da9315a8d47/xgboost-2.1.4-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8df6da72963969ab2bf49a520c3e147b1e15cbeddd3aa0e3e039b3532c739339", size = 223642416, upload-time = "2025-02-06T18:17:25.08Z" },
-    { url = "https://files.pythonhosted.org/packages/43/80/0b5a2dfcf5b4da27b0b68d2833f05d77e1a374d43db951fca200a1f12a52/xgboost-2.1.4-py3-none-win_amd64.whl", hash = "sha256:8bbfe4fedc151b83a52edbf0de945fd94358b09a81998f2945ad330fd5f20cd6", size = 124910381, upload-time = "2025-02-06T18:17:43.202Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- ml/models/spread.py: SpreadModel XGBRegressor wrapper; notebook hyperparameters live in DEFAULT_PARAMS config dict, overridable per instance; save_artifact/load_artifact persist native xgboost model + metadata json in a pluggable artifact dir (MLflow hooks in later in #12)
- ml/train.py: train() builds the matrix from cached pbp/schedule, trains on completed games, writes artifact with feature set, feature cols, seasons, params, and train date; argparse CLI with yaml/json hyperparameter config support
- configs/spread_params.yaml: example override file documenting the notebook baseline params
- make train target (ARGS passthrough)
- deps: declare pyyaml (was transitive); bump xgboost 2.x -> 3.x for scikit-learn 1.9 compat (2.1.4 save_model raises on removed _estimator_type)
- tests: params merge, config loading, artifact round-trip, fixture training end-to-end (train -> load -> predict finite values), CLI