### PR TITLE
L3: augmented team context — ceiling reached, no edge over L2 (#27)

### DIFF
--- a/src/g_nfl/ml/evaluate.py
+++ b/src/g_nfl/ml/evaluate.py
@@ -259,6 +259,7 @@ def backtest(
     epa_splits: bool = False,
     carryover_k: float | None = None,
     with_injuries: bool = False,
+    schedule_ctx: bool = False,
     cache_dir: Path | str = DEFAULT_CACHE_DIR,
     refresh: bool = False,
 ) -> tuple[pl.DataFrame, str]:
@@ -280,6 +281,7 @@ def backtest(
         epa_splits=epa_splits,
         carryover_k=carryover_k,
         injuries=injuries,
+        schedule_ctx=schedule_ctx,
     ).filter(pl.col("result").is_not_null())
 
     fs = get_feature_set(feature_set)
@@ -301,6 +303,7 @@ def backtest(
             "epa_splits": epa_splits,
             "carryover_k": carryover_k,
             "with_injuries": with_injuries,
+            "schedule_ctx": schedule_ctx,
         },
     )
     return preds, report
@@ -339,6 +342,11 @@ def main(argv: list[str] | None = None) -> None:
         help="L3 team-week injury burden features (no lag)",
     )
     parser.add_argument(
+        "--schedule",
+        action="store_true",
+        help="L3 schedule context: rest, short-week/off-bye, day, division",
+    )
+    parser.add_argument(
         "--output", type=Path, help="also write the markdown report to this path"
     )
     parser.add_argument(
@@ -361,6 +369,7 @@ def main(argv: list[str] | None = None) -> None:
         epa_splits=args.epa_splits,
         carryover_k=args.carryover_k,
         with_injuries=args.injuries,
+        schedule_ctx=args.schedule,
         refresh=args.refresh,
     )
     print(report)
@@ -392,6 +401,7 @@ def main(argv: list[str] | None = None) -> None:
                     "epa_splits": args.epa_splits,
                     "carryover_k": args.carryover_k,
                     "with_injuries": args.injuries,
+                    "schedule_ctx": args.schedule,
                     **resolved_params,
                 }
             )

--- a/src/g_nfl/ml/evaluate.py
+++ b/src/g_nfl/ml/evaluate.py
@@ -27,7 +27,7 @@ from typing import Any
 import numpy as np
 import polars as pl
 
-from g_nfl.ml.data import DEFAULT_CACHE_DIR, load_pbp, load_schedule
+from g_nfl.ml.data import DEFAULT_CACHE_DIR, load_injuries, load_pbp, load_schedule
 from g_nfl.ml.features import build_features
 from g_nfl.ml.features.registry import get_feature_set
 from g_nfl.ml.features.windows import DEFAULT_ROLLING_WEEKS
@@ -258,6 +258,7 @@ def backtest(
     half_life: float | None = None,
     epa_splits: bool = False,
     carryover_k: float | None = None,
+    with_injuries: bool = False,
     cache_dir: Path | str = DEFAULT_CACHE_DIR,
     refresh: bool = False,
 ) -> tuple[pl.DataFrame, str]:
@@ -265,6 +266,11 @@ def backtest(
     per-game predictions and the markdown report."""
     pbp = load_pbp(seasons, cache_dir=cache_dir, refresh=refresh)
     schedule = load_schedule(seasons, cache_dir=cache_dir, refresh=refresh)
+    injuries = (
+        load_injuries(seasons, cache_dir=cache_dir, refresh=refresh)
+        if with_injuries
+        else None
+    )
     matrix = build_features(
         pbp,
         schedule,
@@ -273,6 +279,7 @@ def backtest(
         half_life=half_life,
         epa_splits=epa_splits,
         carryover_k=carryover_k,
+        injuries=injuries,
     ).filter(pl.col("result").is_not_null())
 
     fs = get_feature_set(feature_set)
@@ -293,6 +300,7 @@ def backtest(
             "half_life": half_life,
             "epa_splits": epa_splits,
             "carryover_k": carryover_k,
+            "with_injuries": with_injuries,
         },
     )
     return preds, report
@@ -326,6 +334,11 @@ def main(argv: list[str] | None = None) -> None:
         help="L2 prior-season carryover, pseudo-games of prior (omit = off)",
     )
     parser.add_argument(
+        "--injuries",
+        action="store_true",
+        help="L3 team-week injury burden features (no lag)",
+    )
+    parser.add_argument(
         "--output", type=Path, help="also write the markdown report to this path"
     )
     parser.add_argument(
@@ -347,6 +360,7 @@ def main(argv: list[str] | None = None) -> None:
         half_life=args.half_life,
         epa_splits=args.epa_splits,
         carryover_k=args.carryover_k,
+        with_injuries=args.injuries,
         refresh=args.refresh,
     )
     print(report)
@@ -377,6 +391,7 @@ def main(argv: list[str] | None = None) -> None:
                     "half_life": args.half_life,
                     "epa_splits": args.epa_splits,
                     "carryover_k": args.carryover_k,
+                    "with_injuries": args.injuries,
                     **resolved_params,
                 }
             )

--- a/src/g_nfl/ml/features/__init__.py
+++ b/src/g_nfl/ml/features/__init__.py
@@ -11,6 +11,7 @@ Modules:
 
 import polars as pl
 
+from g_nfl.ml.features.context import add_schedule_context
 from g_nfl.ml.features.injuries import add_injuries
 from g_nfl.ml.features.matrix import build_game_matrix
 from g_nfl.ml.features.plays import play_features
@@ -30,6 +31,7 @@ def build_features(
     epa_splits: bool = False,
     carryover_k: float | None = None,
     injuries: pl.DataFrame | None = None,
+    schedule_ctx: bool = False,
 ) -> pl.DataFrame:
     """Full pipeline: raw pbp + schedule -> game-level training matrix.
 
@@ -40,6 +42,8 @@ def build_features(
     cols (pseudo-games of prior; see `carryover.add_carryover`).
     ``injuries`` (L3) joins home/away team-week injury burden, no lag
     (see `injuries.add_injuries`); None leaves the matrix unchanged.
+    ``schedule_ctx`` (L3) appends rest/day-of-week/division context, no lag
+    (see `context.add_schedule_context`).
     """
     reg_schedule = schedule.filter(pl.col("game_type") == "REG")
     plays = play_features(pbp, wp_filter, epa_splits=epa_splits)
@@ -61,4 +65,6 @@ def build_features(
     )
     if injuries is not None:
         matrix = add_injuries(matrix, injuries)
+    if schedule_ctx:
+        matrix = add_schedule_context(matrix, reg_schedule)
     return matrix

--- a/src/g_nfl/ml/features/__init__.py
+++ b/src/g_nfl/ml/features/__init__.py
@@ -11,6 +11,7 @@ Modules:
 
 import polars as pl
 
+from g_nfl.ml.features.injuries import add_injuries
 from g_nfl.ml.features.matrix import build_game_matrix
 from g_nfl.ml.features.plays import play_features
 from g_nfl.ml.features.team_week import team_week_stats
@@ -28,6 +29,7 @@ def build_features(
     half_life: float | None = None,
     epa_splits: bool = False,
     carryover_k: float | None = None,
+    injuries: pl.DataFrame | None = None,
 ) -> pl.DataFrame:
     """Full pipeline: raw pbp + schedule -> game-level training matrix.
 
@@ -36,6 +38,8 @@ def build_features(
     ``epa_splits`` adds the L2 pass/rush/early-down EPA features.
     ``carryover_k`` (flat path) adds prior-season-carryover ``_carry`` rate
     cols (pseudo-games of prior; see `carryover.add_carryover`).
+    ``injuries`` (L3) joins home/away team-week injury burden, no lag
+    (see `injuries.add_injuries`); None leaves the matrix unchanged.
     """
     reg_schedule = schedule.filter(pl.col("game_type") == "REG")
     plays = play_features(pbp, wp_filter, epa_splits=epa_splits)
@@ -47,7 +51,7 @@ def build_features(
         half_life=half_life,
         carryover_k=carryover_k,
     )
-    return build_game_matrix(
+    matrix = build_game_matrix(
         windowed,
         reg_schedule,
         rolling_weeks,
@@ -55,3 +59,6 @@ def build_features(
         half_life=half_life,
         carryover_k=carryover_k,
     )
+    if injuries is not None:
+        matrix = add_injuries(matrix, injuries)
+    return matrix

--- a/src/g_nfl/ml/features/context.py
+++ b/src/g_nfl/ml/features/context.py
@@ -1,0 +1,31 @@
+"""L3 schedule context: rest, short-week / off-bye, day-of-week, division.
+
+All values come straight off the schedule and are known pre-kickoff, so
+unlike performance stats they need **no lag** — joined on ``game_id``.
+Off by default (see ``build_features`` ``schedule_ctx``).
+"""
+
+import polars as pl
+
+
+def add_schedule_context(matrix: pl.DataFrame, schedule: pl.DataFrame) -> pl.DataFrame:
+    """Append rest/day-of-week/division context columns, joined on game_id.
+
+    ``rest_diff`` is the home minus away rest-day gap (the market's rest
+    edge); ``*_off_bye`` flags >9 days (coming off a bye), ``*_short_week``
+    flags <7 (Thu game after a Sunday); ``thursday``/``monday`` mark the
+    standalone slots; ``div_game`` the divisional matchup. All boolean flags
+    are 0/1 ints so the tree treats them as plain features.
+    """
+    ctx = schedule.select(
+        "game_id",
+        rest_diff=pl.col("home_rest") - pl.col("away_rest"),
+        home_off_bye=(pl.col("home_rest") > 9).cast(pl.Int8),
+        away_off_bye=(pl.col("away_rest") > 9).cast(pl.Int8),
+        home_short_week=(pl.col("home_rest") < 7).cast(pl.Int8),
+        away_short_week=(pl.col("away_rest") < 7).cast(pl.Int8),
+        thursday=(pl.col("weekday") == "Thursday").cast(pl.Int8),
+        monday=(pl.col("weekday") == "Monday").cast(pl.Int8),
+        div_game=pl.col("div_game").cast(pl.Int8),
+    )
+    return matrix.join(ctx, on="game_id", how="left")

--- a/src/g_nfl/ml/features/injuries.py
+++ b/src/g_nfl/ml/features/injuries.py
@@ -39,7 +39,7 @@ def team_week_injuries(injuries: pl.DataFrame) -> pl.DataFrame:
     designated = (
         injuries.with_columns(pl.col("report_status").cast(pl.Utf8))
         .filter(
-            (pl.col("season_type") == "REG")
+            (pl.col("game_type") == "REG")
             & pl.col("report_status").is_in(list(STATUS_WEIGHTS))
         )
         .with_columns(
@@ -83,4 +83,27 @@ def team_week_injuries(injuries: pl.DataFrame) -> pl.DataFrame:
         )
         .select("team", "season", "week", *expected)
         .fill_null(0)
+    )
+
+
+def add_injuries(matrix: pl.DataFrame, injuries: pl.DataFrame) -> pl.DataFrame:
+    """Join home/away team-week injury burden onto the game matrix.
+
+    **No lag** (unlike the performance stats in `matrix`): the injury
+    report for a game's week is known pre-kickoff, so we join on the
+    game's *own* (season, week). Team-weeks with no designated injuries
+    have no row in the aggregate and get 0 after the left join.
+    """
+    tw = team_week_injuries(injuries).with_columns(
+        pl.col("season").cast(matrix.schema["season"]),
+        pl.col("week").cast(matrix.schema["week"]),
+    )
+    inj_cols = [c for c in tw.columns if c.startswith("inj_")]
+    away = tw.rename({"team": "away_team", **{c: f"away_{c}" for c in inj_cols}})
+    home = tw.rename({"team": "home_team", **{c: f"home_{c}" for c in inj_cols}})
+    fill = [f"{side}_{c}" for side in ("away", "home") for c in inj_cols]
+    return (
+        matrix.join(away, on=["away_team", "season", "week"], how="left")
+        .join(home, on=["home_team", "season", "week"], how="left")
+        .with_columns(pl.col(fill).fill_null(0))
     )

--- a/tests/test_ml_features.py
+++ b/tests/test_ml_features.py
@@ -372,6 +372,56 @@ def test_future_weeks_do_not_leak(
     assert_frame_equal(base_c.sort("game_id"), pert_c.sort("game_id"))
 
 
+# ---- L3 injuries ----
+
+
+def _injuries(rows: list[tuple[str, int, str, str]]) -> pl.DataFrame:
+    """(team, week, position, report_status) rows for 2023 REG."""
+    return pl.DataFrame(
+        {
+            "season": [2023] * len(rows),
+            "game_type": ["REG"] * len(rows),
+            "team": [r[0] for r in rows],
+            "week": [r[1] for r in rows],
+            "position": [r[2] for r in rows],
+            "report_status": [r[3] for r in rows],
+        }
+    )
+
+
+def test_injuries_join_own_week_no_lag(
+    pbp_sample: pl.DataFrame, schedule_sample: pl.DataFrame
+):
+    # KC QB Out in week 2 only: the week-2 game carries it on KC's side
+    # (own week, no lag); all other KC weeks and the opponent stay 0.
+    inj = _injuries([("KC", 2, "QB", "Out")])
+    base = build_features(pbp_sample, schedule_sample)
+    out = build_features(pbp_sample, schedule_sample, injuries=inj)
+
+    # only injury cols are added; the baseline matrix is untouched
+    added = set(out.columns) - set(base.columns)
+    assert added == {
+        f"{side}_inj_{g}_{m}"
+        for side in ("home", "away")
+        for g in ("qb", "skill", "ol", "def")
+        for m in ("out", "q", "burden")
+    }
+
+    kc = (pl.col("home_team") == "KC") | (pl.col("away_team") == "KC")
+    wk2 = out.filter((pl.col("week") == 2) & kc)
+    assert wk2.height == 1
+    r = wk2.row(0, named=True)
+    side = "home" if r["home_team"] == "KC" else "away"
+    other = "away" if side == "home" else "home"
+    assert r[f"{side}_inj_qb_out"] == 1
+    assert r[f"{other}_inj_qb_out"] == 0  # opponent has no injuries -> 0-filled
+
+    # no lag and no bleed: every other KC week shows qb_out == 0
+    for r in out.filter((pl.col("week") != 2) & kc).iter_rows(named=True):
+        side = "home" if r["home_team"] == "KC" else "away"
+        assert r[f"{side}_inj_qb_out"] == 0
+
+
 # ---- registry ----
 
 

--- a/tests/test_ml_features.py
+++ b/tests/test_ml_features.py
@@ -422,6 +422,36 @@ def test_injuries_join_own_week_no_lag(
         assert r[f"{side}_inj_qb_out"] == 0
 
 
+# ---- L3 schedule context ----
+
+
+def test_schedule_context_cols_and_values(
+    pbp_sample: pl.DataFrame, schedule_sample: pl.DataFrame
+):
+    base = build_features(pbp_sample, schedule_sample)
+    out = build_features(pbp_sample, schedule_sample, schedule_ctx=True)
+
+    assert set(out.columns) - set(base.columns) == {
+        "rest_diff",
+        "home_off_bye",
+        "away_off_bye",
+        "home_short_week",
+        "away_short_week",
+        "thursday",
+        "monday",
+        "div_game",
+    }
+    assert out.height == base.height  # join on game_id drops nothing
+
+    reg = schedule_sample.filter(pl.col("game_type") == "REG").select(
+        "game_id", "home_rest", "away_rest"
+    )
+    chk = out.join(reg, on="game_id").with_columns(
+        exp=pl.col("home_rest") - pl.col("away_rest")
+    )
+    assert (chk["rest_diff"] == chk["exp"]).all()
+
+
 # ---- registry ----
 
 

--- a/tests/test_ml_injuries.py
+++ b/tests/test_ml_injuries.py
@@ -7,11 +7,11 @@ from g_nfl.ml.features.injuries import team_week_injuries
 
 
 def _report(rows: list[tuple[str, int, str, str, str | None]]) -> pl.DataFrame:
-    """(team, week, position, report_status, season_type) rows."""
+    """(team, week, position, report_status, game_type) rows."""
     return pl.DataFrame(
         {
             "season": [2025] * len(rows),
-            "season_type": [r[4] or "REG" for r in rows],
+            "game_type": [r[4] or "REG" for r in rows],
             "team": [r[0] for r in rows],
             "week": [r[1] for r in rows],
             "position": [r[2] for r in rows],


### PR DESCRIPTION
Closes #27.

## Outcome: L3 ceiling reached — no L3 lever beat the L2 baseline. BASELINES unchanged.

Two levers with the strongest priors were built, A/B'd on the tuning split (2018/19/22/23, L2 base **51.4% full-set / 51.2% top-5**), and both came back **neutral**. Code is kept as **off-by-default infra** (baseline untouched when off).

| lever | best tuning result | verdict |
|------|--------------------|---------|
| injury burden (`--injuries`) | 51.8 / 50.5 (qb-burden subset) | neutral — top-5 ≤ base everywhere, all sub-1σ |
| schedule/rest (`--schedule`) | off-bye flags 52.8 / 52.8 | neutral — one-season (2022 +4.6, 2023 −1.4), fragile (washes to base when other cols added) |

### The finding
L1, L2, and L3 all fail the **same way**: the model's most confident disagreements with the market are exactly where the market is right, and **team-grain** context (performance, injuries, schedule) can't crack it. The bottleneck is **grain, not feature kind**. The injury result is the tell — a team's QB-out *count* is neutral, but *which* QB (starter vs backup, plus the QB-specific line move) is a player-grain signal L3 structurally can't represent. → **L4 player-grain.**

### Also fixes a latent #18 bug
`team_week_injuries` filtered `season_type`, which does not exist in `load_injuries` (the column is `game_type`; REG vs WC). It would have crashed the first time it touched real data. Fixed + tests updated.

## Changes
- `features/injuries.py` — `add_injuries` (no-lag own-week home/away join) + `game_type` fix
- `features/context.py` (new) — `add_schedule_context` (rest/off-bye/short-week/day/division, no lag)
- `features/__init__.py` — off-by-default `injuries` + `schedule_ctx` args threaded through `build_features`
- `evaluate.py` — `--injuries` / `--schedule` flags, config + MLflow logging
- tests — own-week/no-lag injury test, schedule-context correctness test (81 pass, lint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)