### PR TITLE
feat(fantasy): season-long player projections — QB/RB/WR/TE (#30)

### DIFF
--- a/src/g_nfl/fantasy/projections/season.py
+++ b/src/g_nfl/fantasy/projections/season.py
@@ -17,6 +17,10 @@ _FB_TO_RB: dict[str, str] = {"FB": "RB"}
 DEFAULT_WEIGHTS: tuple[float, ...] = (0.6, 0.3, 0.1)
 # ponytail: flat 17-game denominator — availability / injury modeling deferred to #31.
 DEFAULT_GAMES: int = 17
+# Drop player-seasons under this many games: a tiny sample (e.g. a 1-game backup)
+# inflates per-game scoring and ranks like a starter. Whole-player drops out if all
+# their seasons are thin.
+DEFAULT_MIN_GAMES: int = 6
 
 _SCORING_OPTIONS = {"standard", "ppr", "half"}
 
@@ -45,11 +49,14 @@ def load_player_seasons(seasons: list[int]) -> pl.DataFrame:
     )
 
 
-def _scored_ppg(df: pl.DataFrame, scoring: str) -> pl.DataFrame:
+def _scored_ppg(
+    df: pl.DataFrame, scoring: str, min_games: int = DEFAULT_MIN_GAMES
+) -> pl.DataFrame:
     """Add a ``ppg`` column (fantasy points per game) for the given scoring type.
 
-    games == 0 rows produce null ppg and are dropped; this is the right call
-    because a zero-game season carries no signal for projection.
+    Player-seasons under ``min_games`` are dropped: a tiny sample inflates
+    per-game scoring (a 1-game backup ranking like a starter). ``min_games=0``
+    keeps everything with at least one game played.
     """
     if scoring not in _SCORING_OPTIONS:
         raise ValueError(f"scoring must be one of {_SCORING_OPTIONS}, got {scoring!r}")
@@ -61,12 +68,11 @@ def _scored_ppg(df: pl.DataFrame, scoring: str) -> pl.DataFrame:
     else:  # half
         pts = (pl.col("fantasy_points") + pl.col("fantasy_points_ppr")) / 2
 
-    return df.with_columns(
-        pl.when(pl.col("games") > 0)
-        .then(pts / pl.col("games"))
-        .otherwise(None)
-        .alias("ppg")
-    ).filter(pl.col("ppg").is_not_null())
+    return (
+        df.filter(pl.col("games") >= max(min_games, 1))
+        .with_columns((pts / pl.col("games")).alias("ppg"))
+        .filter(pl.col("ppg").is_not_null())
+    )
 
 
 def blend_projections(
@@ -144,6 +150,7 @@ def project_season(
     scoring: str = "ppr",
     weights: tuple[float, ...] = DEFAULT_WEIGHTS,
     games: int = DEFAULT_GAMES,
+    min_games: int = DEFAULT_MIN_GAMES,
 ) -> pl.DataFrame:
     """Project fantasy points for ``target_season`` from ``seasons`` of history.
 
@@ -155,6 +162,7 @@ def project_season(
         scoring: One of "standard", "ppr", "half".
         weights: Recency weights; index 0 = most recent prior season.
         games: Games to project over (flat; availability modeling deferred to #31).
+        min_games: Drop player-seasons under this many games (tiny-sample filter).
 
     Returns:
         One row per player, sorted by proj_points descending.
@@ -164,7 +172,7 @@ def project_season(
     )
 
     raw = load_player_seasons(seasons)
-    scored = _scored_ppg(raw, scoring)
+    scored = _scored_ppg(raw, scoring, min_games)
     return blend_projections(scored, target_season, weights, games)
 
 

--- a/src/g_nfl/fantasy/projections/season.py
+++ b/src/g_nfl/fantasy/projections/season.py
@@ -1,0 +1,199 @@
+"""Season-long fantasy projections (input layer for PAR draft board, issue #30).
+
+Blends per-season PPG across N prior seasons with recency weights, renormalised
+for players missing some seasons.  Output is one row per player ready for #31.
+"""
+
+from __future__ import annotations
+
+import nflreadpy as nfl
+import polars as pl
+
+FANTASY_POSITIONS: set[str] = {"QB", "RB", "WR", "TE", "FB"}
+
+# ponytail: FB is rare and scores like RB; collapse rather than add a position slot.
+_FB_TO_RB: dict[str, str] = {"FB": "RB"}
+
+DEFAULT_WEIGHTS: tuple[float, ...] = (0.6, 0.3, 0.1)
+# ponytail: flat 17-game denominator — availability / injury modeling deferred to #31.
+DEFAULT_GAMES: int = 17
+
+_SCORING_OPTIONS = {"standard", "ppr", "half"}
+
+
+def load_player_seasons(seasons: list[int]) -> pl.DataFrame:
+    """Load and normalize player season stats via nflreadpy.
+
+    Filters to FANTASY_POSITIONS (drops null positions), maps FB -> RB,
+    selects the columns needed downstream.
+    """
+    raw: pl.DataFrame = nfl.load_player_stats(seasons=seasons, summary_level="reg")
+
+    return (
+        raw.filter(pl.col("position").is_in(FANTASY_POSITIONS))
+        .with_columns(pl.col("position").replace(_FB_TO_RB).alias("position"))
+        .select(
+            "player_id",
+            "player_name",
+            "position",
+            "recent_team",
+            "season",
+            "games",
+            "fantasy_points",
+            "fantasy_points_ppr",
+        )
+    )
+
+
+def _scored_ppg(df: pl.DataFrame, scoring: str) -> pl.DataFrame:
+    """Add a ``ppg`` column (fantasy points per game) for the given scoring type.
+
+    games == 0 rows produce null ppg and are dropped; this is the right call
+    because a zero-game season carries no signal for projection.
+    """
+    if scoring not in _SCORING_OPTIONS:
+        raise ValueError(f"scoring must be one of {_SCORING_OPTIONS}, got {scoring!r}")
+
+    if scoring == "standard":
+        pts = pl.col("fantasy_points")
+    elif scoring == "ppr":
+        pts = pl.col("fantasy_points_ppr")
+    else:  # half
+        pts = (pl.col("fantasy_points") + pl.col("fantasy_points_ppr")) / 2
+
+    return df.with_columns(
+        pl.when(pl.col("games") > 0)
+        .then(pts / pl.col("games"))
+        .otherwise(None)
+        .alias("ppg")
+    ).filter(pl.col("ppg").is_not_null())
+
+
+def blend_projections(
+    df: pl.DataFrame,
+    target_season: int,
+    weights: tuple[float, ...],
+    games: int,
+) -> pl.DataFrame:
+    """Pure blending step — takes an already-loaded frame with a ``ppg`` column.
+
+    ``df`` must contain: player_id, player_name, position, recent_team, season, ppg.
+    Seasons in ``df`` must all be < ``target_season``.
+
+    Weight assignment: sort each player's seasons descending (most recent first),
+    zip with weights in order, renormalise over seasons the player actually has.
+    """
+    # Rank each season per player by recency (1 = most recent)
+    ranked = df.with_columns(
+        pl.col("season")
+        .rank(method="ordinal", descending=True)
+        .over("player_id")
+        .alias("_rank")
+    )
+
+    # Attach raw weight by rank index (rank 1 -> weights[0], etc.)
+    # Ranks beyond len(weights) get weight 0 and will be excluded.
+    max_rank = len(weights)
+    weight_map = pl.DataFrame(
+        {"_rank": list(range(1, max_rank + 1)), "_w": list(weights)},
+        schema={"_rank": pl.Int32, "_w": pl.Float64},
+    )
+
+    joined = ranked.join(weight_map, on="_rank", how="left").with_columns(
+        pl.col("_w").fill_null(0.0)
+    )
+
+    # Per-player: sum weights over present seasons (for renormalisation)
+    player_wsum = joined.group_by("player_id").agg(pl.col("_w").sum().alias("_wsum"))
+
+    blended = (
+        joined.join(player_wsum, on="player_id", how="left")
+        .with_columns(
+            # renormalised contribution of each season row
+            (pl.col("ppg") * pl.col("_w") / pl.col("_wsum")).alias("_contrib")
+        )
+        .group_by("player_id")
+        .agg(
+            pl.col("player_name").last(),
+            pl.col("position").last(),
+            # most recent team
+            pl.col("recent_team").sort_by(pl.col("season")).last().alias("last_team"),
+            pl.col("season").count().alias("n_seasons"),
+            pl.col("_contrib").sum().alias("proj_ppg"),
+        )
+        .with_columns((pl.col("proj_ppg") * games).alias("proj_points"))
+        .select(
+            "player_id",
+            "player_name",
+            "position",
+            "last_team",
+            "n_seasons",
+            "proj_ppg",
+            "proj_points",
+        )
+        .sort("proj_points", descending=True)
+    )
+
+    return blended
+
+
+def project_season(
+    seasons: list[int],
+    target_season: int,
+    *,
+    scoring: str = "ppr",
+    weights: tuple[float, ...] = DEFAULT_WEIGHTS,
+    games: int = DEFAULT_GAMES,
+) -> pl.DataFrame:
+    """Project fantasy points for ``target_season`` from ``seasons`` of history.
+
+    Args:
+        seasons: Historical seasons to load; should be the N seasons immediately
+            before ``target_season`` (length should equal len(weights), but extra
+            seasons are allowed — weights renormalise).
+        target_season: The season being projected (used only for the assertion).
+        scoring: One of "standard", "ppr", "half".
+        weights: Recency weights; index 0 = most recent prior season.
+        games: Games to project over (flat; availability modeling deferred to #31).
+
+    Returns:
+        One row per player, sorted by proj_points descending.
+    """
+    assert all(s < target_season for s in seasons), (
+        f"All seasons must be < target_season={target_season}"
+    )
+
+    raw = load_player_seasons(seasons)
+    scored = _scored_ppg(raw, scoring)
+    return blend_projections(scored, target_season, weights, games)
+
+
+if __name__ == "__main__":
+    TARGET = 2025
+    SEASONS = [2022, 2023, 2024]
+
+    print(f"Projecting {TARGET} from {SEASONS} (PPR, weights={DEFAULT_WEIGHTS})\n")
+
+    proj = project_season(SEASONS, TARGET)
+
+    print("=== Top 10 overall ===")
+    print(
+        proj.head(10).select(
+            "player_name",
+            "position",
+            "last_team",
+            "n_seasons",
+            "proj_ppg",
+            "proj_points",
+        )
+    )
+
+    print("\n=== Top 5 per position ===")
+    for pos in ["QB", "RB", "WR", "TE"]:
+        top5 = proj.filter(pl.col("position") == pos).head(5)
+        print(f"\n-- {pos} --")
+        print(
+            top5.select(
+                "player_name", "last_team", "n_seasons", "proj_ppg", "proj_points"
+            )
+        )

--- a/tests/test_fantasy_season.py
+++ b/tests/test_fantasy_season.py
@@ -169,6 +169,24 @@ def test_scored_ppg_invalid_scoring():
         _scored_ppg(FRAME, "invalid")
 
 
+def test_scored_ppg_min_games_drops_thin_sample():
+    """A thin player-season (below min_games) is dropped, but min_games=0 keeps it."""
+    frame = _make_frame(
+        {
+            "player_id": "BKP",
+            "player_name": "One Game Backup",
+            "position": "QB",
+            "recent_team": "NYG",
+            "season": 2024,
+            "games": 1,
+            "fantasy_points": 21.0,
+            "fantasy_points_ppr": 21.0,
+        },
+    )
+    assert len(_scored_ppg(frame, "ppr", min_games=6)) == 0
+    assert len(_scored_ppg(frame, "ppr", min_games=0)) == 1
+
+
 # ---------------------------------------------------------------------------
 # blend_projections
 # ---------------------------------------------------------------------------

--- a/tests/test_fantasy_season.py
+++ b/tests/test_fantasy_season.py
@@ -1,0 +1,251 @@
+"""Tests for g_nfl.fantasy.projections.season (issue #30).
+
+All tests are network-free; they build synthetic polars frames and
+exercise the pure functions directly.
+"""
+
+import polars as pl
+import pytest
+
+from g_nfl.fantasy.projections.season import (
+    DEFAULT_GAMES,
+    _scored_ppg,
+    blend_projections,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_frame(*rows: dict) -> pl.DataFrame:
+    """Build a minimal player-season frame from dicts."""
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "player_name": pl.Utf8,
+            "position": pl.Utf8,
+            "recent_team": pl.Utf8,
+            "season": pl.Int32,
+            "games": pl.Int32,
+            "fantasy_points": pl.Float64,
+            "fantasy_points_ppr": pl.Float64,
+        },
+    )
+
+
+# A WR with 3 seasons; TE with 2; QB with 1 (oldest only); FB to normalise.
+FRAME = _make_frame(
+    # WR — 3 seasons
+    {
+        "player_id": "WR1",
+        "player_name": "Star WR",
+        "position": "WR",
+        "recent_team": "KC",
+        "season": 2024,
+        "games": 16,
+        "fantasy_points": 200.0,
+        "fantasy_points_ppr": 280.0,
+    },
+    {
+        "player_id": "WR1",
+        "player_name": "Star WR",
+        "position": "WR",
+        "recent_team": "KC",
+        "season": 2023,
+        "games": 17,
+        "fantasy_points": 180.0,
+        "fantasy_points_ppr": 260.0,
+    },
+    {
+        "player_id": "WR1",
+        "player_name": "Star WR",
+        "position": "WR",
+        "recent_team": "KC",
+        "season": 2022,
+        "games": 15,
+        "fantasy_points": 160.0,
+        "fantasy_points_ppr": 220.0,
+    },
+    # TE — 2 seasons
+    {
+        "player_id": "TE1",
+        "player_name": "Solid TE",
+        "position": "TE",
+        "recent_team": "SF",
+        "season": 2024,
+        "games": 17,
+        "fantasy_points": 140.0,
+        "fantasy_points_ppr": 180.0,
+    },
+    {
+        "player_id": "TE1",
+        "player_name": "Solid TE",
+        "position": "TE",
+        "recent_team": "SF",
+        "season": 2023,
+        "games": 14,
+        "fantasy_points": 120.0,
+        "fantasy_points_ppr": 155.0,
+    },
+    # QB — only oldest season (index 2 in a 3-weight tuple, weight 0.1)
+    {
+        "player_id": "QB1",
+        "player_name": "Old QB",
+        "position": "QB",
+        "recent_team": "DAL",
+        "season": 2022,
+        "games": 17,
+        "fantasy_points": 280.0,
+        "fantasy_points_ppr": 282.0,
+    },
+    # FB — should become RB after load_player_seasons normalisation
+    {
+        "player_id": "FB1",
+        "player_name": "Block Back",
+        "position": "FB",
+        "recent_team": "NE",
+        "season": 2024,
+        "games": 12,
+        "fantasy_points": 30.0,
+        "fantasy_points_ppr": 45.0,
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# _scored_ppg
+# ---------------------------------------------------------------------------
+
+
+def test_scored_ppg_standard():
+    scored = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "standard")
+    row = scored.filter(pl.col("season") == 2024).row(0, named=True)
+    assert abs(row["ppg"] - 200.0 / 16) < 1e-9
+
+
+def test_scored_ppg_ppr():
+    scored = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "ppr")
+    row = scored.filter(pl.col("season") == 2024).row(0, named=True)
+    assert abs(row["ppg"] - 280.0 / 16) < 1e-9
+
+
+def test_scored_ppg_half():
+    scored = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "half")
+    row = scored.filter(pl.col("season") == 2024).row(0, named=True)
+    expected = ((200.0 + 280.0) / 2) / 16
+    assert abs(row["ppg"] - expected) < 1e-9
+
+
+def test_ppr_gte_standard_for_pass_catcher():
+    """PPR ppg >= standard ppg for a receiver (they have receptions)."""
+    s_std = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "standard")
+    s_ppr = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "ppr")
+    std_vals = s_std["ppg"].to_list()
+    ppr_vals = s_ppr["ppg"].to_list()
+    assert all(p >= s for p, s in zip(ppr_vals, std_vals, strict=True))
+
+
+def test_scored_ppg_zero_games_dropped():
+    frame = _make_frame(
+        {
+            "player_id": "X",
+            "player_name": "No Games",
+            "position": "RB",
+            "recent_team": "XX",
+            "season": 2024,
+            "games": 0,
+            "fantasy_points": 10.0,
+            "fantasy_points_ppr": 15.0,
+        },
+    )
+    scored = _scored_ppg(frame, "ppr")
+    assert len(scored) == 0, "zero-game rows should be dropped"
+
+
+def test_scored_ppg_invalid_scoring():
+    with pytest.raises(ValueError, match="scoring must be one of"):
+        _scored_ppg(FRAME, "invalid")
+
+
+# ---------------------------------------------------------------------------
+# blend_projections
+# ---------------------------------------------------------------------------
+
+
+def _scored(scoring: str = "ppr") -> pl.DataFrame:
+    return _scored_ppg(FRAME, scoring)
+
+
+def test_weights_renormalise_single_season():
+    """QB1 only has 2022 data; with weights (0.6,0.3,0.1) its only present
+    season gets rank 1 but... wait — QB1 only exists in the oldest season
+    (2022), which would be rank 3 (least recent) if all 3 seasons were
+    present.  After renorm, its weight == 1.0 regardless, so proj_ppg ==
+    that season's ppg.
+    """
+    scored = _scored("ppr")
+    result = blend_projections(scored, 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    qb_row = result.filter(pl.col("player_id") == "QB1").row(0, named=True)
+    # QB1 has only one season; ppg = 282 / 17
+    expected_ppg = 282.0 / 17
+    assert abs(qb_row["proj_ppg"] - expected_ppg) < 1e-6
+
+
+def test_proj_points_equals_ppg_times_games():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    for row in result.iter_rows(named=True):
+        assert abs(row["proj_points"] - row["proj_ppg"] * DEFAULT_GAMES) < 1e-6
+
+
+def test_n_seasons_correct():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    assert result.filter(pl.col("player_id") == "WR1")["n_seasons"][0] == 3
+    assert result.filter(pl.col("player_id") == "TE1")["n_seasons"][0] == 2
+    assert result.filter(pl.col("player_id") == "QB1")["n_seasons"][0] == 1
+
+
+def test_sorted_descending():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    pts = result["proj_points"].to_list()
+    assert pts == sorted(pts, reverse=True)
+
+
+def test_last_team_is_most_recent():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    wr_row = result.filter(pl.col("player_id") == "WR1").row(0, named=True)
+    assert wr_row["last_team"] == "KC"
+
+
+# ---------------------------------------------------------------------------
+# FB -> RB normalisation (via load_player_seasons round-trip through _scored)
+# ---------------------------------------------------------------------------
+
+
+def test_fb_normalised_to_rb():
+    """FB1 in FRAME has position FB; after _scored_ppg (which doesn't touch
+    position) and blend_projections it should still appear as FB because
+    load_player_seasons is the normalisation point.
+
+    Test the normalisation directly on a minimal frame that mimics the
+    load_player_seasons output (where FB is already mapped to RB).
+    """
+    fb_frame = _make_frame(
+        {
+            "player_id": "FB1",
+            "player_name": "Block Back",
+            "position": "FB",
+            "recent_team": "NE",
+            "season": 2024,
+            "games": 12,
+            "fantasy_points": 30.0,
+            "fantasy_points_ppr": 45.0,
+        },
+    )
+    # Simulate what load_player_seasons does: replace FB -> RB
+    normalised = fb_frame.with_columns(
+        pl.col("position").replace({"FB": "RB"}).alias("position")
+    )
+    scored = _scored_ppg(normalised, "ppr")
+    assert scored.filter(pl.col("player_id") == "FB1")["position"][0] == "RB"


### PR DESCRIPTION
Closes #30.

Season-long fantasy projections extended to QB/RB/WR/TE (was RB-only weekly tool).

## What
- `season.py`: recency-weighted PPG blend over N prior seasons (default 0.6/0.3/0.1), renormalised for players missing seasons, flat 17-game denominator. polars + nflreadpy. FB collapsed to RB.
- `min_games` floor (default 6): drops thin player-seasons that inflate per-game scoring (a 1-game backup was ranking like a top-5 QB). `min_games=0` restores raw.

## Verify
- 13 network-free tests (`tests/test_fantasy_season.py`), all green.
- `python -m g_nfl.fantasy.projections.season` prints sane top-10 + top-5/position (Allen/Jackson/Hurts QB, Barkley/Gibbs RB, Chase/Jefferson WR, Bowers/Kittle TE).

Input layer for #31 (PAR/VOR draft board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)