### PR TITLE
feat(fantasy): PPGAR draft board from Sleeper lineup config (#31)

### DIFF
--- a/src/g_nfl/fantasy/projections/board.py
+++ b/src/g_nfl/fantasy/projections/board.py
@@ -1,0 +1,170 @@
+"""Per-game points-above-replacement (PPGAR) draft board (issue #31).
+
+Takes #30 season projections and a league's starting-lineup config, derives a
+replacement-level per-game baseline per position, and ranks every player by
+``ppgar = proj_ppg - replacement_ppg(position)`` so positions are comparable.
+
+Per-game (not season-total) on purpose: the #30 backtest showed a large positive
+level bias from the flat 17-game denominator. PPGAR compares rate to rate, so
+games-played cancels on both player and baseline.
+
+Replacement baseline = the best *non-starting* player at each position, found by a
+greedy leaguewide lineup fill: dedicated slots first, then each FLEX / SUPER_FLEX
+slot takes the best eligible player still on the board. The first player who
+doesn't make any starting lineup sets that position's replacement level.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import polars as pl
+
+from g_nfl.sleeper.client import SleeperClient
+
+# Positions we project + rank. K/DEF have no #30 projection -> excluded.
+BOARD_POSITIONS: tuple[str, ...] = ("QB", "RB", "WR", "TE")
+
+# Flex slot name -> positions eligible to fill it. Covers Sleeper's common flex
+# labels; unknown slot names (K, DEF, BN, IR, taxi, dedicated) are ignored.
+FLEX_ELIGIBILITY: dict[str, frozenset[str]] = {
+    "FLEX": frozenset({"RB", "WR", "TE"}),
+    "WRRB_FLEX": frozenset({"RB", "WR"}),
+    "REC_FLEX": frozenset({"WR", "TE"}),
+    "SUPER_FLEX": frozenset({"QB", "RB", "WR", "TE"}),
+}
+
+
+def replacement_baselines(
+    proj: pl.DataFrame, teams: int, roster_positions: list[str]
+) -> dict[str, float]:
+    """Per-position replacement-level ``proj_ppg`` via greedy leaguewide fill.
+
+    ``proj`` needs ``position`` + ``proj_ppg`` (the #30 output). ``roster_positions``
+    is Sleeper's per-team starting-slot list (incl. BN/K/DEF, which are ignored).
+    Returns ``{pos: replacement_ppg}`` — the ppg of the first non-startable player.
+    """
+    slots = Counter(roster_positions)
+
+    # Per-position pools: proj_ppg sorted best-first.
+    pools: dict[str, list[float]] = {
+        pos: proj.filter(pl.col("position") == pos)
+        .sort("proj_ppg", descending=True)["proj_ppg"]
+        .to_list()
+        for pos in BOARD_POSITIONS
+    }
+    used: dict[str, int] = {pos: 0 for pos in BOARD_POSITIONS}
+
+    # Dedicated slots: teams * slot count off the top of each pool.
+    for pos in BOARD_POSITIONS:
+        used[pos] = min(slots.get(pos, 0) * teams, len(pools[pos]))
+
+    # Flex slots: each instance takes the best eligible player still on the board.
+    flex_instances = [
+        ftype
+        for slot, n in slots.items()
+        if slot in FLEX_ELIGIBILITY
+        for ftype in [slot] * (n * teams)
+    ]
+    for ftype in flex_instances:
+        elig = FLEX_ELIGIBILITY[ftype]
+        best_pos, best_val = None, float("-inf")
+        for pos in elig:
+            if used[pos] < len(pools[pos]) and pools[pos][used[pos]] > best_val:
+                best_pos, best_val = pos, pools[pos][used[pos]]
+        if best_pos is not None:
+            used[best_pos] += 1
+
+    # Replacement = first non-starter; clamp to last available if pool exhausted.
+    return {
+        pos: pools[pos][min(used[pos], len(pools[pos]) - 1)]
+        for pos in BOARD_POSITIONS
+        if pools[pos]
+    }
+
+
+def build_board(
+    proj: pl.DataFrame, teams: int, roster_positions: list[str]
+) -> pl.DataFrame:
+    """Attach replacement baselines + PPGAR, rank across positions.
+
+    Returns ``proj`` (BOARD_POSITIONS only) plus ``replacement_ppg``, ``ppgar``,
+    ``overall_rank`` (by ppgar desc), and ``pos_rank``; sorted by ppgar.
+    """
+    baselines = replacement_baselines(proj, teams, roster_positions)
+    repl = pl.DataFrame(
+        {"position": list(baselines), "replacement_ppg": list(baselines.values())}
+    )
+    return (
+        proj.filter(pl.col("position").is_in(BOARD_POSITIONS))
+        .join(repl, on="position", how="inner")
+        .with_columns((pl.col("proj_ppg") - pl.col("replacement_ppg")).alias("ppgar"))
+        .sort("ppgar", descending=True)
+        .with_columns(
+            pl.int_range(1, pl.len() + 1).alias("overall_rank"),
+            pl.col("ppgar")
+            .rank("ordinal", descending=True)
+            .over("position")
+            .alias("pos_rank"),
+        )
+    )
+
+
+def board_for_league(
+    proj: pl.DataFrame, league_id: str, client: SleeperClient | None = None
+) -> pl.DataFrame:
+    """Build a board from a live Sleeper league's size + starting lineup."""
+    client = client or SleeperClient()
+    lg = client.league(league_id)
+    return build_board(proj, lg["total_rosters"], lg["roster_positions"])
+
+
+def to_markdown(board: pl.DataFrame, top: int = 60) -> str:
+    """Render the top-``top`` rows as a markdown table."""
+    cols = [
+        "overall_rank",
+        "player_name",
+        "position",
+        "pos_rank",
+        "last_team",
+        "proj_ppg",
+        "ppgar",
+    ]
+    rows = board.head(top).select(cols).iter_rows()
+    head = "| " + " | ".join(cols) + " |"
+    sep = "|" + "|".join("---" for _ in cols) + "|"
+    body = "\n".join(
+        "| "
+        + " | ".join(f"{c:.2f}" if isinstance(c, float) else str(c) for c in r)
+        + " |"
+        for r in rows
+    )
+    return f"{head}\n{sep}\n{body}"
+
+
+if __name__ == "__main__":
+    from pathlib import Path
+
+    from g_nfl.fantasy.projections.season import project_season
+    from g_nfl.sleeper.client import KNOWN_LEAGUES
+
+    TARGET = 2025
+    proj = project_season([2022, 2023, 2024], TARGET, scoring="half")
+
+    client = SleeperClient()
+    lid = KNOWN_LEAGUES["dudes_rock"]
+    lg = client.league(lid)
+    print(f"League {lg['name']}: {lg['total_rosters']} teams")
+    print(
+        "Baselines (half-PPR ppg):",
+        replacement_baselines(proj, lg["total_rosters"], lg["roster_positions"]),
+    )
+
+    board = build_board(proj, lg["total_rosters"], lg["roster_positions"])
+    md = to_markdown(board, top=50)
+    print("\n" + md)
+
+    out = Path("data") / "fantasy" / f"board_{TARGET}.md"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(f"# PPGAR board {TARGET} — {lg['name']}\n\n{md}\n")
+    print(f"\nWrote {out}")

--- a/src/g_nfl/fantasy/projections/season.py
+++ b/src/g_nfl/fantasy/projections/season.py
@@ -17,6 +17,10 @@ _FB_TO_RB: dict[str, str] = {"FB": "RB"}
 DEFAULT_WEIGHTS: tuple[float, ...] = (0.6, 0.3, 0.1)
 # ponytail: flat 17-game denominator — availability / injury modeling deferred to #31.
 DEFAULT_GAMES: int = 17
+# Drop player-seasons under this many games: a tiny sample (e.g. a 1-game backup)
+# inflates per-game scoring and ranks like a starter. Whole-player drops out if all
+# their seasons are thin.
+DEFAULT_MIN_GAMES: int = 6
 
 _SCORING_OPTIONS = {"standard", "ppr", "half"}
 
@@ -45,11 +49,14 @@ def load_player_seasons(seasons: list[int]) -> pl.DataFrame:
     )
 
 
-def _scored_ppg(df: pl.DataFrame, scoring: str) -> pl.DataFrame:
+def _scored_ppg(
+    df: pl.DataFrame, scoring: str, min_games: int = DEFAULT_MIN_GAMES
+) -> pl.DataFrame:
     """Add a ``ppg`` column (fantasy points per game) for the given scoring type.
 
-    games == 0 rows produce null ppg and are dropped; this is the right call
-    because a zero-game season carries no signal for projection.
+    Player-seasons under ``min_games`` are dropped: a tiny sample inflates
+    per-game scoring (a 1-game backup ranking like a starter). ``min_games=0``
+    keeps everything with at least one game played.
     """
     if scoring not in _SCORING_OPTIONS:
         raise ValueError(f"scoring must be one of {_SCORING_OPTIONS}, got {scoring!r}")
@@ -61,12 +68,11 @@ def _scored_ppg(df: pl.DataFrame, scoring: str) -> pl.DataFrame:
     else:  # half
         pts = (pl.col("fantasy_points") + pl.col("fantasy_points_ppr")) / 2
 
-    return df.with_columns(
-        pl.when(pl.col("games") > 0)
-        .then(pts / pl.col("games"))
-        .otherwise(None)
-        .alias("ppg")
-    ).filter(pl.col("ppg").is_not_null())
+    return (
+        df.filter(pl.col("games") >= max(min_games, 1))
+        .with_columns((pts / pl.col("games")).alias("ppg"))
+        .filter(pl.col("ppg").is_not_null())
+    )
 
 
 def blend_projections(
@@ -144,6 +150,7 @@ def project_season(
     scoring: str = "ppr",
     weights: tuple[float, ...] = DEFAULT_WEIGHTS,
     games: int = DEFAULT_GAMES,
+    min_games: int = DEFAULT_MIN_GAMES,
 ) -> pl.DataFrame:
     """Project fantasy points for ``target_season`` from ``seasons`` of history.
 
@@ -155,6 +162,7 @@ def project_season(
         scoring: One of "standard", "ppr", "half".
         weights: Recency weights; index 0 = most recent prior season.
         games: Games to project over (flat; availability modeling deferred to #31).
+        min_games: Drop player-seasons under this many games (tiny-sample filter).
 
     Returns:
         One row per player, sorted by proj_points descending.
@@ -164,7 +172,7 @@ def project_season(
     )
 
     raw = load_player_seasons(seasons)
-    scored = _scored_ppg(raw, scoring)
+    scored = _scored_ppg(raw, scoring, min_games)
     return blend_projections(scored, target_season, weights, games)
 
 

--- a/src/g_nfl/fantasy/projections/season.py
+++ b/src/g_nfl/fantasy/projections/season.py
@@ -1,0 +1,199 @@
+"""Season-long fantasy projections (input layer for PAR draft board, issue #30).
+
+Blends per-season PPG across N prior seasons with recency weights, renormalised
+for players missing some seasons.  Output is one row per player ready for #31.
+"""
+
+from __future__ import annotations
+
+import nflreadpy as nfl
+import polars as pl
+
+FANTASY_POSITIONS: set[str] = {"QB", "RB", "WR", "TE", "FB"}
+
+# ponytail: FB is rare and scores like RB; collapse rather than add a position slot.
+_FB_TO_RB: dict[str, str] = {"FB": "RB"}
+
+DEFAULT_WEIGHTS: tuple[float, ...] = (0.6, 0.3, 0.1)
+# ponytail: flat 17-game denominator — availability / injury modeling deferred to #31.
+DEFAULT_GAMES: int = 17
+
+_SCORING_OPTIONS = {"standard", "ppr", "half"}
+
+
+def load_player_seasons(seasons: list[int]) -> pl.DataFrame:
+    """Load and normalize player season stats via nflreadpy.
+
+    Filters to FANTASY_POSITIONS (drops null positions), maps FB -> RB,
+    selects the columns needed downstream.
+    """
+    raw: pl.DataFrame = nfl.load_player_stats(seasons=seasons, summary_level="reg")
+
+    return (
+        raw.filter(pl.col("position").is_in(FANTASY_POSITIONS))
+        .with_columns(pl.col("position").replace(_FB_TO_RB).alias("position"))
+        .select(
+            "player_id",
+            "player_name",
+            "position",
+            "recent_team",
+            "season",
+            "games",
+            "fantasy_points",
+            "fantasy_points_ppr",
+        )
+    )
+
+
+def _scored_ppg(df: pl.DataFrame, scoring: str) -> pl.DataFrame:
+    """Add a ``ppg`` column (fantasy points per game) for the given scoring type.
+
+    games == 0 rows produce null ppg and are dropped; this is the right call
+    because a zero-game season carries no signal for projection.
+    """
+    if scoring not in _SCORING_OPTIONS:
+        raise ValueError(f"scoring must be one of {_SCORING_OPTIONS}, got {scoring!r}")
+
+    if scoring == "standard":
+        pts = pl.col("fantasy_points")
+    elif scoring == "ppr":
+        pts = pl.col("fantasy_points_ppr")
+    else:  # half
+        pts = (pl.col("fantasy_points") + pl.col("fantasy_points_ppr")) / 2
+
+    return df.with_columns(
+        pl.when(pl.col("games") > 0)
+        .then(pts / pl.col("games"))
+        .otherwise(None)
+        .alias("ppg")
+    ).filter(pl.col("ppg").is_not_null())
+
+
+def blend_projections(
+    df: pl.DataFrame,
+    target_season: int,
+    weights: tuple[float, ...],
+    games: int,
+) -> pl.DataFrame:
+    """Pure blending step — takes an already-loaded frame with a ``ppg`` column.
+
+    ``df`` must contain: player_id, player_name, position, recent_team, season, ppg.
+    Seasons in ``df`` must all be < ``target_season``.
+
+    Weight assignment: sort each player's seasons descending (most recent first),
+    zip with weights in order, renormalise over seasons the player actually has.
+    """
+    # Rank each season per player by recency (1 = most recent)
+    ranked = df.with_columns(
+        pl.col("season")
+        .rank(method="ordinal", descending=True)
+        .over("player_id")
+        .alias("_rank")
+    )
+
+    # Attach raw weight by rank index (rank 1 -> weights[0], etc.)
+    # Ranks beyond len(weights) get weight 0 and will be excluded.
+    max_rank = len(weights)
+    weight_map = pl.DataFrame(
+        {"_rank": list(range(1, max_rank + 1)), "_w": list(weights)},
+        schema={"_rank": pl.Int32, "_w": pl.Float64},
+    )
+
+    joined = ranked.join(weight_map, on="_rank", how="left").with_columns(
+        pl.col("_w").fill_null(0.0)
+    )
+
+    # Per-player: sum weights over present seasons (for renormalisation)
+    player_wsum = joined.group_by("player_id").agg(pl.col("_w").sum().alias("_wsum"))
+
+    blended = (
+        joined.join(player_wsum, on="player_id", how="left")
+        .with_columns(
+            # renormalised contribution of each season row
+            (pl.col("ppg") * pl.col("_w") / pl.col("_wsum")).alias("_contrib")
+        )
+        .group_by("player_id")
+        .agg(
+            pl.col("player_name").last(),
+            pl.col("position").last(),
+            # most recent team
+            pl.col("recent_team").sort_by(pl.col("season")).last().alias("last_team"),
+            pl.col("season").count().alias("n_seasons"),
+            pl.col("_contrib").sum().alias("proj_ppg"),
+        )
+        .with_columns((pl.col("proj_ppg") * games).alias("proj_points"))
+        .select(
+            "player_id",
+            "player_name",
+            "position",
+            "last_team",
+            "n_seasons",
+            "proj_ppg",
+            "proj_points",
+        )
+        .sort("proj_points", descending=True)
+    )
+
+    return blended
+
+
+def project_season(
+    seasons: list[int],
+    target_season: int,
+    *,
+    scoring: str = "ppr",
+    weights: tuple[float, ...] = DEFAULT_WEIGHTS,
+    games: int = DEFAULT_GAMES,
+) -> pl.DataFrame:
+    """Project fantasy points for ``target_season`` from ``seasons`` of history.
+
+    Args:
+        seasons: Historical seasons to load; should be the N seasons immediately
+            before ``target_season`` (length should equal len(weights), but extra
+            seasons are allowed — weights renormalise).
+        target_season: The season being projected (used only for the assertion).
+        scoring: One of "standard", "ppr", "half".
+        weights: Recency weights; index 0 = most recent prior season.
+        games: Games to project over (flat; availability modeling deferred to #31).
+
+    Returns:
+        One row per player, sorted by proj_points descending.
+    """
+    assert all(s < target_season for s in seasons), (
+        f"All seasons must be < target_season={target_season}"
+    )
+
+    raw = load_player_seasons(seasons)
+    scored = _scored_ppg(raw, scoring)
+    return blend_projections(scored, target_season, weights, games)
+
+
+if __name__ == "__main__":
+    TARGET = 2025
+    SEASONS = [2022, 2023, 2024]
+
+    print(f"Projecting {TARGET} from {SEASONS} (PPR, weights={DEFAULT_WEIGHTS})\n")
+
+    proj = project_season(SEASONS, TARGET)
+
+    print("=== Top 10 overall ===")
+    print(
+        proj.head(10).select(
+            "player_name",
+            "position",
+            "last_team",
+            "n_seasons",
+            "proj_ppg",
+            "proj_points",
+        )
+    )
+
+    print("\n=== Top 5 per position ===")
+    for pos in ["QB", "RB", "WR", "TE"]:
+        top5 = proj.filter(pl.col("position") == pos).head(5)
+        print(f"\n-- {pos} --")
+        print(
+            top5.select(
+                "player_name", "last_team", "n_seasons", "proj_ppg", "proj_points"
+            )
+        )

--- a/tests/test_fantasy_board.py
+++ b/tests/test_fantasy_board.py
@@ -1,0 +1,80 @@
+"""Tests for g_nfl.fantasy.projections.board (issue #31). Network-free."""
+
+import polars as pl
+
+from g_nfl.fantasy.projections.board import build_board, replacement_baselines
+
+
+def _proj(*rows: tuple[str, str, float]) -> pl.DataFrame:
+    """(player_name, position, proj_ppg) -> minimal projection frame."""
+    return pl.DataFrame(
+        {
+            "player_id": [r[0] for r in rows],
+            "player_name": [r[0] for r in rows],
+            "position": [r[1] for r in rows],
+            "last_team": ["XX"] * len(rows),
+            "proj_ppg": [r[2] for r in rows],
+            "proj_points": [r[2] * 17 for r in rows],
+        }
+    )
+
+
+def test_replacement_is_first_non_starter():
+    """2 teams, 1 QB slot each -> 2 QBs start; QB3 is replacement."""
+    proj = _proj(
+        ("QB1", "QB", 30.0),
+        ("QB2", "QB", 25.0),
+        ("QB3", "QB", 20.0),
+        ("QB4", "QB", 15.0),
+    )
+    base = replacement_baselines(proj, teams=2, roster_positions=["QB"])
+    assert base["QB"] == 20.0  # QB3, first off the bench
+
+
+def test_flex_consumes_best_eligible():
+    """1 team: 1 RB + 1 FLEX(RB/WR/TE). Best non-RB-starter eligible fills flex.
+
+    RB1 takes the dedicated RB. FLEX then picks the best remaining among
+    {RB,WR,TE}: RB2 (18) beats WR1 (17), so RB2 starts -> RB replacement = RB3.
+    """
+    proj = _proj(
+        ("RB1", "RB", 20.0),
+        ("RB2", "RB", 18.0),
+        ("RB3", "RB", 10.0),
+        ("WR1", "WR", 17.0),
+        ("WR2", "WR", 8.0),
+    )
+    base = replacement_baselines(proj, teams=1, roster_positions=["RB", "FLEX"])
+    assert base["RB"] == 10.0  # RB3 first off bench (RB1 dedicated, RB2 flex)
+    assert base["WR"] == 17.0  # WR1 never started -> it's the replacement
+
+
+def test_superflex_can_take_qb():
+    """SUPER_FLEX is QB-eligible: a strong QB2 fills it, raising the QB baseline."""
+    proj = _proj(
+        ("QB1", "QB", 30.0),
+        ("QB2", "QB", 28.0),
+        ("QB3", "QB", 12.0),
+        ("RB1", "RB", 20.0),
+        ("RB2", "RB", 9.0),
+    )
+    base = replacement_baselines(
+        proj, teams=1, roster_positions=["QB", "RB", "SUPER_FLEX"]
+    )
+    # QB1 dedicated, QB2 (28) beats RB2 (9) for SF -> QB3 is replacement.
+    assert base["QB"] == 12.0
+
+
+def test_ppgar_and_ranks():
+    proj = _proj(
+        ("QB1", "QB", 30.0),
+        ("QB2", "QB", 20.0),
+        ("RB1", "RB", 25.0),
+        ("RB2", "RB", 10.0),
+    )
+    board = build_board(proj, teams=1, roster_positions=["QB", "RB"])
+    # baselines: QB2=20, RB2=10. ppgar: QB1=10, RB1=15, QB2=0, RB2=0.
+    rb1 = board.filter(pl.col("player_id") == "RB1").row(0, named=True)
+    assert abs(rb1["ppgar"] - 15.0) < 1e-9
+    assert rb1["overall_rank"] == 1  # RB1 ppgar 15 > QB1 ppgar 10
+    assert board["overall_rank"].to_list() == sorted(board["overall_rank"].to_list())

--- a/tests/test_fantasy_season.py
+++ b/tests/test_fantasy_season.py
@@ -169,6 +169,24 @@ def test_scored_ppg_invalid_scoring():
         _scored_ppg(FRAME, "invalid")
 
 
+def test_scored_ppg_min_games_drops_thin_sample():
+    """A thin player-season (below min_games) is dropped, but min_games=0 keeps it."""
+    frame = _make_frame(
+        {
+            "player_id": "BKP",
+            "player_name": "One Game Backup",
+            "position": "QB",
+            "recent_team": "NYG",
+            "season": 2024,
+            "games": 1,
+            "fantasy_points": 21.0,
+            "fantasy_points_ppr": 21.0,
+        },
+    )
+    assert len(_scored_ppg(frame, "ppr", min_games=6)) == 0
+    assert len(_scored_ppg(frame, "ppr", min_games=0)) == 1
+
+
 # ---------------------------------------------------------------------------
 # blend_projections
 # ---------------------------------------------------------------------------

--- a/tests/test_fantasy_season.py
+++ b/tests/test_fantasy_season.py
@@ -1,0 +1,251 @@
+"""Tests for g_nfl.fantasy.projections.season (issue #30).
+
+All tests are network-free; they build synthetic polars frames and
+exercise the pure functions directly.
+"""
+
+import polars as pl
+import pytest
+
+from g_nfl.fantasy.projections.season import (
+    DEFAULT_GAMES,
+    _scored_ppg,
+    blend_projections,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_frame(*rows: dict) -> pl.DataFrame:
+    """Build a minimal player-season frame from dicts."""
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "player_name": pl.Utf8,
+            "position": pl.Utf8,
+            "recent_team": pl.Utf8,
+            "season": pl.Int32,
+            "games": pl.Int32,
+            "fantasy_points": pl.Float64,
+            "fantasy_points_ppr": pl.Float64,
+        },
+    )
+
+
+# A WR with 3 seasons; TE with 2; QB with 1 (oldest only); FB to normalise.
+FRAME = _make_frame(
+    # WR — 3 seasons
+    {
+        "player_id": "WR1",
+        "player_name": "Star WR",
+        "position": "WR",
+        "recent_team": "KC",
+        "season": 2024,
+        "games": 16,
+        "fantasy_points": 200.0,
+        "fantasy_points_ppr": 280.0,
+    },
+    {
+        "player_id": "WR1",
+        "player_name": "Star WR",
+        "position": "WR",
+        "recent_team": "KC",
+        "season": 2023,
+        "games": 17,
+        "fantasy_points": 180.0,
+        "fantasy_points_ppr": 260.0,
+    },
+    {
+        "player_id": "WR1",
+        "player_name": "Star WR",
+        "position": "WR",
+        "recent_team": "KC",
+        "season": 2022,
+        "games": 15,
+        "fantasy_points": 160.0,
+        "fantasy_points_ppr": 220.0,
+    },
+    # TE — 2 seasons
+    {
+        "player_id": "TE1",
+        "player_name": "Solid TE",
+        "position": "TE",
+        "recent_team": "SF",
+        "season": 2024,
+        "games": 17,
+        "fantasy_points": 140.0,
+        "fantasy_points_ppr": 180.0,
+    },
+    {
+        "player_id": "TE1",
+        "player_name": "Solid TE",
+        "position": "TE",
+        "recent_team": "SF",
+        "season": 2023,
+        "games": 14,
+        "fantasy_points": 120.0,
+        "fantasy_points_ppr": 155.0,
+    },
+    # QB — only oldest season (index 2 in a 3-weight tuple, weight 0.1)
+    {
+        "player_id": "QB1",
+        "player_name": "Old QB",
+        "position": "QB",
+        "recent_team": "DAL",
+        "season": 2022,
+        "games": 17,
+        "fantasy_points": 280.0,
+        "fantasy_points_ppr": 282.0,
+    },
+    # FB — should become RB after load_player_seasons normalisation
+    {
+        "player_id": "FB1",
+        "player_name": "Block Back",
+        "position": "FB",
+        "recent_team": "NE",
+        "season": 2024,
+        "games": 12,
+        "fantasy_points": 30.0,
+        "fantasy_points_ppr": 45.0,
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# _scored_ppg
+# ---------------------------------------------------------------------------
+
+
+def test_scored_ppg_standard():
+    scored = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "standard")
+    row = scored.filter(pl.col("season") == 2024).row(0, named=True)
+    assert abs(row["ppg"] - 200.0 / 16) < 1e-9
+
+
+def test_scored_ppg_ppr():
+    scored = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "ppr")
+    row = scored.filter(pl.col("season") == 2024).row(0, named=True)
+    assert abs(row["ppg"] - 280.0 / 16) < 1e-9
+
+
+def test_scored_ppg_half():
+    scored = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "half")
+    row = scored.filter(pl.col("season") == 2024).row(0, named=True)
+    expected = ((200.0 + 280.0) / 2) / 16
+    assert abs(row["ppg"] - expected) < 1e-9
+
+
+def test_ppr_gte_standard_for_pass_catcher():
+    """PPR ppg >= standard ppg for a receiver (they have receptions)."""
+    s_std = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "standard")
+    s_ppr = _scored_ppg(FRAME.filter(pl.col("player_id") == "WR1"), "ppr")
+    std_vals = s_std["ppg"].to_list()
+    ppr_vals = s_ppr["ppg"].to_list()
+    assert all(p >= s for p, s in zip(ppr_vals, std_vals, strict=True))
+
+
+def test_scored_ppg_zero_games_dropped():
+    frame = _make_frame(
+        {
+            "player_id": "X",
+            "player_name": "No Games",
+            "position": "RB",
+            "recent_team": "XX",
+            "season": 2024,
+            "games": 0,
+            "fantasy_points": 10.0,
+            "fantasy_points_ppr": 15.0,
+        },
+    )
+    scored = _scored_ppg(frame, "ppr")
+    assert len(scored) == 0, "zero-game rows should be dropped"
+
+
+def test_scored_ppg_invalid_scoring():
+    with pytest.raises(ValueError, match="scoring must be one of"):
+        _scored_ppg(FRAME, "invalid")
+
+
+# ---------------------------------------------------------------------------
+# blend_projections
+# ---------------------------------------------------------------------------
+
+
+def _scored(scoring: str = "ppr") -> pl.DataFrame:
+    return _scored_ppg(FRAME, scoring)
+
+
+def test_weights_renormalise_single_season():
+    """QB1 only has 2022 data; with weights (0.6,0.3,0.1) its only present
+    season gets rank 1 but... wait — QB1 only exists in the oldest season
+    (2022), which would be rank 3 (least recent) if all 3 seasons were
+    present.  After renorm, its weight == 1.0 regardless, so proj_ppg ==
+    that season's ppg.
+    """
+    scored = _scored("ppr")
+    result = blend_projections(scored, 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    qb_row = result.filter(pl.col("player_id") == "QB1").row(0, named=True)
+    # QB1 has only one season; ppg = 282 / 17
+    expected_ppg = 282.0 / 17
+    assert abs(qb_row["proj_ppg"] - expected_ppg) < 1e-6
+
+
+def test_proj_points_equals_ppg_times_games():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    for row in result.iter_rows(named=True):
+        assert abs(row["proj_points"] - row["proj_ppg"] * DEFAULT_GAMES) < 1e-6
+
+
+def test_n_seasons_correct():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    assert result.filter(pl.col("player_id") == "WR1")["n_seasons"][0] == 3
+    assert result.filter(pl.col("player_id") == "TE1")["n_seasons"][0] == 2
+    assert result.filter(pl.col("player_id") == "QB1")["n_seasons"][0] == 1
+
+
+def test_sorted_descending():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    pts = result["proj_points"].to_list()
+    assert pts == sorted(pts, reverse=True)
+
+
+def test_last_team_is_most_recent():
+    result = blend_projections(_scored(), 2025, (0.6, 0.3, 0.1), DEFAULT_GAMES)
+    wr_row = result.filter(pl.col("player_id") == "WR1").row(0, named=True)
+    assert wr_row["last_team"] == "KC"
+
+
+# ---------------------------------------------------------------------------
+# FB -> RB normalisation (via load_player_seasons round-trip through _scored)
+# ---------------------------------------------------------------------------
+
+
+def test_fb_normalised_to_rb():
+    """FB1 in FRAME has position FB; after _scored_ppg (which doesn't touch
+    position) and blend_projections it should still appear as FB because
+    load_player_seasons is the normalisation point.
+
+    Test the normalisation directly on a minimal frame that mimics the
+    load_player_seasons output (where FB is already mapped to RB).
+    """
+    fb_frame = _make_frame(
+        {
+            "player_id": "FB1",
+            "player_name": "Block Back",
+            "position": "FB",
+            "recent_team": "NE",
+            "season": 2024,
+            "games": 12,
+            "fantasy_points": 30.0,
+            "fantasy_points_ppr": 45.0,
+        },
+    )
+    # Simulate what load_player_seasons does: replace FB -> RB
+    normalised = fb_frame.with_columns(
+        pl.col("position").replace({"FB": "RB"}).alias("position")
+    )
+    scored = _scored_ppg(normalised, "ppr")
+    assert scored.filter(pl.col("player_id") == "FB1")["position"][0] == "RB"


### PR DESCRIPTION
## Summary
- Per-game points-above-replacement (PPGAR) draft board: `ppgar = proj_ppg - replacement_ppg(position)`, comparable across positions.
- Replacement baseline derived from a Sleeper league's team count + starting-lineup config via greedy leaguewide fill (dedicated slots first, then FLEX/SUPER_FLEX takes best eligible remaining).
- Ranks across QB/RB/WR/TE (K/DEF excluded, no #30 projection); exports ranked markdown board.
- Depends on #30 (season-long projections for QB/RB/WR/TE), already merged into this branch.

## Test plan
- [x] `uv run pytest tests/test_fantasy_board.py tests/test_fantasy_season.py` — 17 passed
- [x] `make lint` — clean
- [x] Ran `python -m g_nfl.fantasy.projections.board` end-to-end against real Sleeper league (Dudes Rock Dynasty, 10 teams) — output sane (McCaffrey/Barkley top, RB scarcity reflected, QBs ranked by VOR not raw points)

Closes #31.