### PR TITLE
feat(fantasy): WR/TE receiving efficiency diagnostics (#34)

### DIFF
--- a/src/g_nfl/fantasy/projections/board.py
+++ b/src/g_nfl/fantasy/projections/board.py
@@ -119,8 +119,20 @@ def board_for_league(
     return build_board(proj, lg["total_rosters"], lg["roster_positions"])
 
 
+def attach_efficiency_rates(board: pl.DataFrame, rates: pl.DataFrame) -> pl.DataFrame:
+    """Left-join WR/TE diagnostic efficiency rates (tprr/yprr/fdrr) onto a
+    board for eyeballing; QB/RB rows get nulls. Diagnostic only — does not
+    touch ppgar/rank (issue #34: the z-score ppg adjustment backtested
+    mixed/negative, see ``efficiency.py`` module docstring).
+    """
+    return board.join(rates, on="player_id", how="left")
+
+
 def to_markdown(board: pl.DataFrame, top: int = 60) -> str:
-    """Render the top-``top`` rows as a markdown table."""
+    """Render the top-``top`` rows as a markdown table.
+
+    Includes ``tprr``/``yprr``/``fdrr`` if present (see ``attach_efficiency_rates``).
+    """
     cols = [
         "overall_rank",
         "player_name",
@@ -130,26 +142,32 @@ def to_markdown(board: pl.DataFrame, top: int = 60) -> str:
         "proj_ppg",
         "ppgar",
     ]
+    cols += [c for c in ("tprr", "yprr", "fdrr") if c in board.columns]
     rows = board.head(top).select(cols).iter_rows()
     head = "| " + " | ".join(cols) + " |"
     sep = "|" + "|".join("---" for _ in cols) + "|"
-    body = "\n".join(
-        "| "
-        + " | ".join(f"{c:.2f}" if isinstance(c, float) else str(c) for c in r)
-        + " |"
-        for r in rows
-    )
+
+    def _fmt(c: object) -> str:
+        if c is None:
+            return "-"
+        if isinstance(c, float):
+            return f"{c:.2f}"
+        return str(c)
+
+    body = "\n".join("| " + " | ".join(_fmt(c) for c in r) + " |" for r in rows)
     return f"{head}\n{sep}\n{body}"
 
 
 if __name__ == "__main__":
     from pathlib import Path
 
+    from g_nfl.fantasy.projections.efficiency import blend_efficiency_rates
     from g_nfl.fantasy.projections.season import project_season
     from g_nfl.sleeper.client import KNOWN_LEAGUES
 
     TARGET = 2025
-    proj = project_season([2022, 2023, 2024], TARGET, scoring="half")
+    SEASONS = [2022, 2023, 2024]
+    proj = project_season(SEASONS, TARGET, scoring="half")
 
     client = SleeperClient()
     lid = KNOWN_LEAGUES["dudes_rock"]
@@ -161,6 +179,8 @@ if __name__ == "__main__":
     )
 
     board = build_board(proj, lg["total_rosters"], lg["roster_positions"])
+    rates = blend_efficiency_rates(SEASONS, TARGET)
+    board = attach_efficiency_rates(board, rates)
     md = to_markdown(board, top=50)
     print("\n" + md)
 

--- a/src/g_nfl/fantasy/projections/efficiency.py
+++ b/src/g_nfl/fantasy/projections/efficiency.py
@@ -1,0 +1,125 @@
+"""Per-route receiving efficiency for WR/TE projections (issue #34).
+
+Derives a routes-run *proxy* from nflreadpy participation data (free, no PFF/
+FantasyPoints needed) and folds it into TPRR / YPRR / 1DRR efficiency rates.
+
+The proxy is every offensive player on the field for a pass play
+(`participation.offense_players`, joined against pbp pass attempts) — not true
+charted routes. `participation.route` is a red herring: it charts the
+*targeted receiver's* route type per play, not a per-player route-run flag.
+
+Validated against PFF's 2023 published numbers:
+- WR: accurate (CeeDee Lamb proxy TPRR 27.6% vs PFF ~27.4%, YPRR 2.67 vs ~2.59).
+- TE: biased high ~10-15% for in-line/blocking TEs (Kittle, Njoku) — the proxy
+  can't separate route-run snaps from pass-pro snaps. Cleaner for flex TEs.
+- RB: unusable (CMC proxy 545 "routes" vs PFF's real ~350) — RBs spend most
+  pass downs blocking. Scoped out; RB stays on the #30 PPG projection.
+"""
+
+from __future__ import annotations
+
+import nflreadpy as nfl
+import polars as pl
+
+EFFICIENCY_POSITIONS: set[str] = {"WR", "TE"}
+
+
+def load_routes_pbp(seasons: list[int]) -> pl.DataFrame:
+    """Pass-play rows (game_id, play_id, season) to drive the routes-run proxy."""
+    pbp: pl.DataFrame = nfl.load_pbp(seasons=seasons)
+    return pbp.filter(pl.col("pass_attempt") == 1).select(
+        "game_id", "play_id", "season"
+    )
+
+
+def load_participation(seasons: list[int]) -> pl.DataFrame:
+    """Participation rows needed for the routes-run proxy."""
+    part: pl.DataFrame = nfl.load_participation(seasons=seasons)
+    return part.select(
+        pl.col("nflverse_game_id").alias("game_id"), "play_id", "offense_players"
+    )
+
+
+def compute_routes_proxy(
+    pass_plays: pl.DataFrame, participation: pl.DataFrame
+) -> pl.DataFrame:
+    """Routes-run proxy per player per season.
+
+    Counts every pass play a player was on the field for offense (per
+    ``offense_players``), restricted to dropbacks via ``pass_plays``.
+    """
+    joined = pass_plays.join(participation, on=["game_id", "play_id"], how="inner")
+    return (
+        joined.with_columns(pl.col("offense_players").str.split(";"))
+        .explode("offense_players")
+        .rename({"offense_players": "player_id"})
+        .group_by("player_id", "season")
+        .agg(pl.len().alias("routes_proxy"))
+    )
+
+
+def compute_efficiency(
+    routes: pl.DataFrame, player_stats: pl.DataFrame
+) -> pl.DataFrame:
+    """TPRR / YPRR / 1DRR per player-season, WR/TE only.
+
+    ``player_stats`` needs: player_id, player_name, position, season, targets,
+    receiving_yards, receiving_first_downs (load_player_stats reg-season cols).
+    """
+    return (
+        routes.join(player_stats, on=["player_id", "season"], how="inner")
+        .filter(pl.col("position").is_in(EFFICIENCY_POSITIONS))
+        .with_columns(
+            (pl.col("targets") / pl.col("routes_proxy")).alias("tprr"),
+            (pl.col("receiving_yards") / pl.col("routes_proxy")).alias("yprr"),
+            (pl.col("receiving_first_downs") / pl.col("routes_proxy")).alias("fdrr"),
+        )
+        .select(
+            "player_id",
+            "player_name",
+            "position",
+            "season",
+            "routes_proxy",
+            "tprr",
+            "yprr",
+            "fdrr",
+        )
+        .sort("yprr", descending=True)
+    )
+
+
+def load_efficiency(seasons: list[int]) -> pl.DataFrame:
+    """Orchestrate: load pbp + participation + player_stats, compute efficiency."""
+    pass_plays = load_routes_pbp(seasons)
+    participation = load_participation(seasons)
+    routes = compute_routes_proxy(pass_plays, participation)
+
+    stats: pl.DataFrame = nfl.load_player_stats(
+        seasons=seasons, summary_level="reg"
+    ).select(
+        "player_id",
+        "player_name",
+        "position",
+        "season",
+        "targets",
+        "receiving_yards",
+        "receiving_first_downs",
+    )
+    return compute_efficiency(routes, stats)
+
+
+if __name__ == "__main__":
+    SEASONS = [2023]
+    MIN_ROUTES = 200
+
+    eff = load_efficiency(SEASONS)
+
+    for pos in ("WR", "TE"):
+        print(f"\n=== Top 10 {pos} by YPRR (min {MIN_ROUTES} routes, {SEASONS}) ===")
+        print(
+            eff.filter(
+                (pl.col("position") == pos) & (pl.col("routes_proxy") >= MIN_ROUTES)
+            )
+            .sort("yprr", descending=True)
+            .head(10)
+        )

--- a/src/g_nfl/fantasy/projections/efficiency.py
+++ b/src/g_nfl/fantasy/projections/efficiency.py
@@ -21,7 +21,27 @@ from __future__ import annotations
 import nflreadpy as nfl
 import polars as pl
 
+from g_nfl.fantasy.projections.season import (
+    DEFAULT_GAMES,
+    DEFAULT_WEIGHTS,
+    _points_expr,
+    _recency_weighted,
+    project_season,
+)
+
 EFFICIENCY_POSITIONS: set[str] = {"WR", "TE"}
+
+# Drop player-seasons under this many routes: mirrors season.py's
+# DEFAULT_MIN_GAMES floor — a tiny route sample makes pprr noisy.
+DEFAULT_MIN_ROUTES: int = 50
+
+# proj_ppg *= (1 + DEFAULT_Z_STRENGTH * pprr_z): a 1-std-dev efficiency edge
+# over position peers is roughly an 8% ppg bump. ponytail: arbitrary starting
+# point, tune via backtest before trusting it.
+DEFAULT_Z_STRENGTH: float = 0.08
+
+# Clip pprr_z before applying it — caps the swing from a small-sample outlier.
+Z_CLIP: float = 2.5
 
 
 def load_routes_pbp(seasons: list[int]) -> pl.DataFrame:
@@ -108,18 +128,189 @@ def load_efficiency(seasons: list[int]) -> pl.DataFrame:
     return compute_efficiency(routes, stats)
 
 
-if __name__ == "__main__":
-    SEASONS = [2023]
-    MIN_ROUTES = 200
+# ---------------------------------------------------------------------------
+# Augmenting season.py's PPG projection (issue #34, "augment" path)
+#
+# First cut multiplied a blended efficiency rate (pprr) back by a blended
+# volume estimate (routes_per_game) derived from the *same* player's own
+# route history. That's circular: pprr * routes_per_game = points / games =
+# ppg exactly, per season, by construction — multiplying two separately
+# blended averages back together doesn't add information, it just
+# reconstructs ppg plus noise from the season-to-season covariance between
+# efficiency and volume. Caught live (deltas were ~0.01-0.08 ppg, not signal).
+#
+# Fix: don't reconstruct volume at all. Compare each player's blended pprr to
+# the WR/TE positional average (z-score) and use that as a quality bump/fade
+# on top of the existing PPG blend's own volume assumption — additive
+# correction, not reconstruction.
+# ---------------------------------------------------------------------------
 
-    eff = load_efficiency(SEASONS)
 
-    for pos in ("WR", "TE"):
-        print(f"\n=== Top 10 {pos} by YPRR (min {MIN_ROUTES} routes, {SEASONS}) ===")
-        print(
-            eff.filter(
-                (pl.col("position") == pos) & (pl.col("routes_proxy") >= MIN_ROUTES)
-            )
-            .sort("yprr", descending=True)
-            .head(10)
+def load_efficiency_inputs(seasons: list[int]) -> pl.DataFrame:
+    """Routes-proxy joined to player-season stats, WR/TE only, games > 0.
+
+    Needs ``games`` + raw points columns, unlike the rate-only
+    ``compute_efficiency``/``load_efficiency`` path above.
+    """
+    pass_plays = load_routes_pbp(seasons)
+    participation = load_participation(seasons)
+    routes = compute_routes_proxy(pass_plays, participation)
+
+    stats: pl.DataFrame = nfl.load_player_stats(
+        seasons=seasons, summary_level="reg"
+    ).select(
+        "player_id",
+        "player_name",
+        "position",
+        "season",
+        "games",
+        "fantasy_points",
+        "fantasy_points_ppr",
+    )
+    return (
+        routes.join(stats, on=["player_id", "season"], how="inner")
+        .filter(pl.col("position").is_in(EFFICIENCY_POSITIONS))
+        .filter(pl.col("games") > 0)
+    )
+
+
+def _scored_efficiency(
+    df: pl.DataFrame, scoring: str, min_routes: int = DEFAULT_MIN_ROUTES
+) -> pl.DataFrame:
+    """Add ``pprr`` (fantasy points per route run); drop thin route samples."""
+    pts = _points_expr(scoring)
+    return df.filter(pl.col("routes_proxy") >= min_routes).with_columns(
+        (pts / pl.col("routes_proxy")).alias("pprr")
+    )
+
+
+def blend_efficiency(scored: pl.DataFrame, weights: tuple[float, ...]) -> pl.DataFrame:
+    """Pure blending step — takes an already-scored frame (``_scored_efficiency``
+    output), recency-blends ``pprr`` per player, and z-scores it against
+    WR/TE position peers (``pprr_z``, clipped to +-``Z_CLIP``).
+    """
+    pprr_blend = _recency_weighted(scored, "pprr", weights)
+    meta = scored.group_by("player_id").agg(
+        pl.col("player_name").last(), pl.col("position").last()
+    )
+
+    mean_pos = pl.col("pprr_proj").mean().over("position")
+    std_pos = pl.col("pprr_proj").std(ddof=0).over("position")
+    z_expr = (
+        pl.when(std_pos > 0)
+        .then((pl.col("pprr_proj") - mean_pos) / std_pos)
+        .otherwise(0.0)
+        .clip(-Z_CLIP, Z_CLIP)
+    )
+
+    return (
+        pprr_blend.join(meta, on="player_id", how="left")
+        .rename({"blended_pprr": "pprr_proj"})
+        .with_columns(z_expr.alias("pprr_z"))
+        .select(
+            "player_id", "player_name", "position", "n_seasons", "pprr_proj", "pprr_z"
         )
+        .sort("pprr_z", descending=True)
+    )
+
+
+def project_efficiency(
+    seasons: list[int],
+    target_season: int,
+    *,
+    scoring: str = "ppr",
+    weights: tuple[float, ...] = DEFAULT_WEIGHTS,
+    min_routes: int = DEFAULT_MIN_ROUTES,
+) -> pl.DataFrame:
+    """Recency-blended efficiency projection, WR/TE only. See ``blend_efficiency``."""
+    assert all(s < target_season for s in seasons), (
+        f"All seasons must be < target_season={target_season}"
+    )
+    raw = load_efficiency_inputs(seasons)
+    scored = _scored_efficiency(raw, scoring, min_routes)
+    return blend_efficiency(scored, weights)
+
+
+def apply_efficiency_adjustment(
+    base: pl.DataFrame,
+    efficiency: pl.DataFrame,
+    strength: float = DEFAULT_Z_STRENGTH,
+    games: int = DEFAULT_GAMES,
+) -> pl.DataFrame:
+    """Scale WR/TE ``proj_ppg`` by ``(1 + strength * pprr_z)`` — a quality
+    bump/fade relative to position peers, layered on the existing PPG blend's
+    volume assumption (not a reconstruction of it; see module docstring).
+    Players without an efficiency row (e.g. below ``DEFAULT_MIN_ROUTES``) or
+    outside WR/TE keep their base ``proj_ppg`` unchanged.
+    """
+    eff = efficiency.select("player_id", "pprr_z")
+    merged = base.join(eff, on="player_id", how="left")
+
+    has_z = pl.col("pprr_z").is_not_null() & pl.col("position").is_in(
+        EFFICIENCY_POSITIONS
+    )
+    adjusted_ppg = (
+        pl.when(has_z)
+        .then(pl.col("proj_ppg") * (1 + strength * pl.col("pprr_z")))
+        .otherwise(pl.col("proj_ppg"))
+    )
+
+    return (
+        merged.with_columns(adjusted_ppg.alias("proj_ppg"))
+        .with_columns((pl.col("proj_ppg") * games).alias("proj_points"))
+        .select(base.columns)
+        .sort("proj_points", descending=True)
+    )
+
+
+def project_season_with_efficiency(
+    seasons: list[int],
+    target_season: int,
+    *,
+    scoring: str = "ppr",
+    weights: tuple[float, ...] = DEFAULT_WEIGHTS,
+    games: int = DEFAULT_GAMES,
+    min_routes: int = DEFAULT_MIN_ROUTES,
+    z_strength: float = DEFAULT_Z_STRENGTH,
+) -> pl.DataFrame:
+    """``project_season`` adjusted by WR/TE route efficiency vs position peers.
+
+    QB/RB are passed through from ``project_season`` unchanged. See
+    ``apply_efficiency_adjustment`` for the adjustment mechanics.
+    """
+    base = project_season(
+        seasons, target_season, scoring=scoring, weights=weights, games=games
+    )
+    efficiency = project_efficiency(
+        seasons, target_season, scoring=scoring, weights=weights, min_routes=min_routes
+    )
+    return apply_efficiency_adjustment(
+        base, efficiency, strength=z_strength, games=games
+    )
+
+
+if __name__ == "__main__":
+    TARGET = 2025
+    SEASONS = [2022, 2023, 2024]
+
+    base = project_season(SEASONS, TARGET)
+    adjusted = project_season_with_efficiency(SEASONS, TARGET)
+
+    print(
+        f"=== WR/TE proj_ppg: PPG-only vs efficiency-adjusted (z_strength={DEFAULT_Z_STRENGTH}) ==="
+    )
+    compare = (
+        base.select(
+            "player_id", "player_name", "position", pl.col("proj_ppg").alias("ppg_only")
+        )
+        .join(
+            adjusted.select("player_id", pl.col("proj_ppg").alias("ppg_adjusted")),
+            on="player_id",
+        )
+        .filter(pl.col("position").is_in(EFFICIENCY_POSITIONS))
+        .with_columns((pl.col("ppg_adjusted") - pl.col("ppg_only")).alias("delta"))
+        .sort("ppg_adjusted", descending=True)
+    )
+    print(compare.head(20))
+    print("\n=== Biggest fades (most negative delta) ===")
+    print(compare.sort("delta").head(10))

--- a/src/g_nfl/fantasy/projections/efficiency.py
+++ b/src/g_nfl/fantasy/projections/efficiency.py
@@ -14,6 +14,13 @@ Validated against PFF's 2023 published numbers:
   can't separate route-run snaps from pass-pro snaps. Cleaner for flex TEs.
 - RB: unusable (CMC proxy 545 "routes" vs PFF's real ~350) — RBs spend most
   pass downs blocking. Scoped out; RB stays on the #30 PPG projection.
+
+The ``apply_efficiency_adjustment`` / ``project_season_with_efficiency`` path
+(z-score proj_ppg bump vs position peers) backtested mixed/negative on a
+single 2022-23 -> 2024 holdout (TE top-12 +1 hit but worse MAE both
+positions; WR unchanged hit-rate, worse MAE) — NOT promoted as trustworthy.
+The #31 draft board uses ``blend_efficiency_rates`` instead: raw TPRR/YPRR/
+1DRR as diagnostic columns, no automatic ppg adjustment.
 """
 
 from __future__ import annotations
@@ -166,6 +173,9 @@ def load_efficiency_inputs(seasons: list[int]) -> pl.DataFrame:
         "games",
         "fantasy_points",
         "fantasy_points_ppr",
+        "targets",
+        "receiving_yards",
+        "receiving_first_downs",
     )
     return (
         routes.join(stats, on=["player_id", "season"], how="inner")
@@ -229,6 +239,62 @@ def project_efficiency(
     raw = load_efficiency_inputs(seasons)
     scored = _scored_efficiency(raw, scoring, min_routes)
     return blend_efficiency(scored, weights)
+
+
+# ---------------------------------------------------------------------------
+# Draft-board diagnostic columns (issue #34, "ship rates, hold the
+# adjustment" — the z_strength backtest came back mixed/negative, see module
+# docstring; TPRR/YPRR/1DRR are useful to eyeball on the board regardless).
+# ---------------------------------------------------------------------------
+
+
+def _scored_rates(
+    df: pl.DataFrame, min_routes: int = DEFAULT_MIN_ROUTES
+) -> pl.DataFrame:
+    """Add raw TPRR/YPRR/1DRR; drop thin route samples."""
+    return df.filter(pl.col("routes_proxy") >= min_routes).with_columns(
+        (pl.col("targets") / pl.col("routes_proxy")).alias("tprr"),
+        (pl.col("receiving_yards") / pl.col("routes_proxy")).alias("yprr"),
+        (pl.col("receiving_first_downs") / pl.col("routes_proxy")).alias("fdrr"),
+    )
+
+
+def blend_rates(scored: pl.DataFrame, weights: tuple[float, ...]) -> pl.DataFrame:
+    """Pure blending step — takes an already-scored frame (``_scored_rates``
+    output) and recency-blends ``tprr``/``yprr``/``fdrr`` per player.
+    """
+    tprr = _recency_weighted(scored, "tprr", weights).select(
+        "player_id", pl.col("blended_tprr").alias("tprr")
+    )
+    yprr = _recency_weighted(scored, "yprr", weights).select(
+        "player_id", pl.col("blended_yprr").alias("yprr")
+    )
+    fdrr = _recency_weighted(scored, "fdrr", weights).select(
+        "player_id", pl.col("blended_fdrr").alias("fdrr")
+    )
+    return tprr.join(yprr, on="player_id", how="left").join(
+        fdrr, on="player_id", how="left"
+    )
+
+
+def blend_efficiency_rates(
+    seasons: list[int],
+    target_season: int,
+    *,
+    weights: tuple[float, ...] = DEFAULT_WEIGHTS,
+    min_routes: int = DEFAULT_MIN_ROUTES,
+) -> pl.DataFrame:
+    """Recency-blended TPRR / YPRR / 1DRR per player, WR/TE only.
+
+    Diagnostic only — does not touch proj_ppg. For the #31 board to display
+    alongside the PPG-only ranking (see ``board.attach_efficiency_rates``).
+    """
+    assert all(s < target_season for s in seasons), (
+        f"All seasons must be < target_season={target_season}"
+    )
+    raw = load_efficiency_inputs(seasons)
+    scored = _scored_rates(raw, min_routes)
+    return blend_rates(scored, weights)
 
 
 def apply_efficiency_adjustment(

--- a/src/g_nfl/fantasy/projections/season.py
+++ b/src/g_nfl/fantasy/projections/season.py
@@ -49,6 +49,19 @@ def load_player_seasons(seasons: list[int]) -> pl.DataFrame:
     )
 
 
+def _points_expr(scoring: str) -> pl.Expr:
+    """Fantasy-points expression for the given scoring type."""
+    if scoring not in _SCORING_OPTIONS:
+        raise ValueError(f"scoring must be one of {_SCORING_OPTIONS}, got {scoring!r}")
+
+    if scoring == "standard":
+        return pl.col("fantasy_points")
+    elif scoring == "ppr":
+        return pl.col("fantasy_points_ppr")
+    else:  # half
+        return (pl.col("fantasy_points") + pl.col("fantasy_points_ppr")) / 2
+
+
 def _scored_ppg(
     df: pl.DataFrame, scoring: str, min_games: int = DEFAULT_MIN_GAMES
 ) -> pl.DataFrame:
@@ -58,16 +71,7 @@ def _scored_ppg(
     per-game scoring (a 1-game backup ranking like a starter). ``min_games=0``
     keeps everything with at least one game played.
     """
-    if scoring not in _SCORING_OPTIONS:
-        raise ValueError(f"scoring must be one of {_SCORING_OPTIONS}, got {scoring!r}")
-
-    if scoring == "standard":
-        pts = pl.col("fantasy_points")
-    elif scoring == "ppr":
-        pts = pl.col("fantasy_points_ppr")
-    else:  # half
-        pts = (pl.col("fantasy_points") + pl.col("fantasy_points_ppr")) / 2
-
+    pts = _points_expr(scoring)
     return (
         df.filter(pl.col("games") >= max(min_games, 1))
         .with_columns((pts / pl.col("games")).alias("ppg"))
@@ -75,19 +79,14 @@ def _scored_ppg(
     )
 
 
-def blend_projections(
-    df: pl.DataFrame,
-    target_season: int,
-    weights: tuple[float, ...],
-    games: int,
+def _recency_weighted(
+    df: pl.DataFrame, value_col: str, weights: tuple[float, ...]
 ) -> pl.DataFrame:
-    """Pure blending step — takes an already-loaded frame with a ``ppg`` column.
+    """Recency-weighted blend of ``value_col`` across each player's seasons.
 
-    ``df`` must contain: player_id, player_name, position, recent_team, season, ppg.
-    Seasons in ``df`` must all be < ``target_season``.
-
-    Weight assignment: sort each player's seasons descending (most recent first),
-    zip with weights in order, renormalise over seasons the player actually has.
+    Sorts each player's seasons descending (most recent first), zips with
+    ``weights`` in order, renormalises over seasons the player actually has.
+    Returns one row per player: ``player_id``, ``blended_{value_col}``, ``n_seasons``.
     """
     # Rank each season per player by recency (1 = most recent)
     ranked = df.with_columns(
@@ -112,21 +111,43 @@ def blend_projections(
     # Per-player: sum weights over present seasons (for renormalisation)
     player_wsum = joined.group_by("player_id").agg(pl.col("_w").sum().alias("_wsum"))
 
-    blended = (
+    blended_col = f"blended_{value_col}"
+    return (
         joined.join(player_wsum, on="player_id", how="left")
         .with_columns(
             # renormalised contribution of each season row
-            (pl.col("ppg") * pl.col("_w") / pl.col("_wsum")).alias("_contrib")
+            (pl.col(value_col) * pl.col("_w") / pl.col("_wsum")).alias("_contrib")
         )
         .group_by("player_id")
         .agg(
-            pl.col("player_name").last(),
-            pl.col("position").last(),
-            # most recent team
-            pl.col("recent_team").sort_by(pl.col("season")).last().alias("last_team"),
+            pl.col("_contrib").sum().alias(blended_col),
             pl.col("season").count().alias("n_seasons"),
-            pl.col("_contrib").sum().alias("proj_ppg"),
         )
+    )
+
+
+def blend_projections(
+    df: pl.DataFrame,
+    target_season: int,
+    weights: tuple[float, ...],
+    games: int,
+) -> pl.DataFrame:
+    """Pure blending step — takes an already-loaded frame with a ``ppg`` column.
+
+    ``df`` must contain: player_id, player_name, position, recent_team, season, ppg.
+    Seasons in ``df`` must all be < ``target_season``.
+    """
+    blended = _recency_weighted(df, "ppg", weights)
+    meta = df.group_by("player_id").agg(
+        pl.col("player_name").last(),
+        pl.col("position").last(),
+        # most recent team
+        pl.col("recent_team").sort_by(pl.col("season")).last().alias("last_team"),
+    )
+
+    return (
+        blended.join(meta, on="player_id", how="left")
+        .rename({"blended_ppg": "proj_ppg"})
         .with_columns((pl.col("proj_ppg") * games).alias("proj_points"))
         .select(
             "player_id",
@@ -139,8 +160,6 @@ def blend_projections(
         )
         .sort("proj_points", descending=True)
     )
-
-    return blended
 
 
 def project_season(

--- a/tests/test_fantasy_board.py
+++ b/tests/test_fantasy_board.py
@@ -2,7 +2,11 @@
 
 import polars as pl
 
-from g_nfl.fantasy.projections.board import build_board, replacement_baselines
+from g_nfl.fantasy.projections.board import (
+    attach_efficiency_rates,
+    build_board,
+    replacement_baselines,
+)
 
 
 def _proj(*rows: tuple[str, str, float]) -> pl.DataFrame:
@@ -78,3 +82,15 @@ def test_ppgar_and_ranks():
     assert abs(rb1["ppgar"] - 15.0) < 1e-9
     assert rb1["overall_rank"] == 1  # RB1 ppgar 15 > QB1 ppgar 10
     assert board["overall_rank"].to_list() == sorted(board["overall_rank"].to_list())
+
+
+def test_attach_efficiency_rates_left_join_nulls_for_missing():
+    board = _proj(("WR1", "WR", 15.0), ("QB1", "QB", 25.0))
+    rates = pl.DataFrame(
+        {"player_id": ["WR1"], "tprr": [0.25], "yprr": [2.0], "fdrr": [0.1]}
+    )
+    attached = attach_efficiency_rates(board, rates)
+    wr_row = attached.filter(pl.col("player_id") == "WR1").row(0, named=True)
+    qb_row = attached.filter(pl.col("player_id") == "QB1").row(0, named=True)
+    assert abs(wr_row["yprr"] - 2.0) < 1e-9
+    assert qb_row["tprr"] is None

--- a/tests/test_fantasy_efficiency.py
+++ b/tests/test_fantasy_efficiency.py
@@ -1,0 +1,168 @@
+"""Tests for g_nfl.fantasy.projections.efficiency (issue #34).
+
+All tests are network-free; they build synthetic polars frames and
+exercise the pure functions directly.
+"""
+
+import polars as pl
+
+from g_nfl.fantasy.projections.efficiency import (
+    compute_efficiency,
+    compute_routes_proxy,
+)
+
+# ---------------------------------------------------------------------------
+# compute_routes_proxy
+# ---------------------------------------------------------------------------
+
+
+def _pass_plays(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={"game_id": pl.Utf8, "play_id": pl.Float64, "season": pl.Int32},
+    )
+
+
+def _participation(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={"game_id": pl.Utf8, "play_id": pl.Float64, "offense_players": pl.Utf8},
+    )
+
+
+def test_routes_proxy_counts_pass_plays_per_player():
+    """Each player on offense for a pass play gets +1 route; non-pass plays
+    in participation that aren't in pass_plays are excluded by the inner join.
+    """
+    pass_plays = _pass_plays(
+        {"game_id": "G1", "play_id": 1.0, "season": 2023},
+        {"game_id": "G1", "play_id": 2.0, "season": 2023},
+    )
+    participation = _participation(
+        {"game_id": "G1", "play_id": 1.0, "offense_players": "WR1;WR2;QB1"},
+        {"game_id": "G1", "play_id": 2.0, "offense_players": "WR1;TE1;QB1"},
+        # run play, not in pass_plays -> dropped by inner join
+        {"game_id": "G1", "play_id": 3.0, "offense_players": "WR1;WR2;QB1"},
+    )
+    routes = compute_routes_proxy(pass_plays, participation)
+    counts = dict(zip(routes["player_id"], routes["routes_proxy"], strict=True))
+    assert counts == {"WR1": 2, "WR2": 1, "TE1": 1, "QB1": 2}
+
+
+def test_routes_proxy_grouped_by_season():
+    pass_plays = _pass_plays(
+        {"game_id": "G1", "play_id": 1.0, "season": 2022},
+        {"game_id": "G2", "play_id": 1.0, "season": 2023},
+    )
+    participation = _participation(
+        {"game_id": "G1", "play_id": 1.0, "offense_players": "WR1"},
+        {"game_id": "G2", "play_id": 1.0, "offense_players": "WR1"},
+    )
+    routes = compute_routes_proxy(pass_plays, participation)
+    seasons = dict(zip(routes["season"], routes["routes_proxy"], strict=True))
+    assert seasons == {2022: 1, 2023: 1}
+
+
+# ---------------------------------------------------------------------------
+# compute_efficiency
+# ---------------------------------------------------------------------------
+
+
+def _routes(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={"player_id": pl.Utf8, "season": pl.Int32, "routes_proxy": pl.UInt32},
+    )
+
+
+def _stats(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "player_name": pl.Utf8,
+            "position": pl.Utf8,
+            "season": pl.Int32,
+            "targets": pl.Int32,
+            "receiving_yards": pl.Float64,
+            "receiving_first_downs": pl.Int32,
+        },
+    )
+
+
+def test_efficiency_rates_computed_correctly():
+    routes = _routes({"player_id": "WR1", "season": 2023, "routes_proxy": 100})
+    stats = _stats(
+        {
+            "player_id": "WR1",
+            "player_name": "Star WR",
+            "position": "WR",
+            "season": 2023,
+            "targets": 25,
+            "receiving_yards": 250.0,
+            "receiving_first_downs": 12,
+        }
+    )
+    eff = compute_efficiency(routes, stats)
+    row = eff.row(0, named=True)
+    assert abs(row["tprr"] - 0.25) < 1e-9
+    assert abs(row["yprr"] - 2.5) < 1e-9
+    assert abs(row["fdrr"] - 0.12) < 1e-9
+
+
+def test_efficiency_excludes_non_wr_te():
+    routes = _routes(
+        {"player_id": "RB1", "season": 2023, "routes_proxy": 100},
+        {"player_id": "WR1", "season": 2023, "routes_proxy": 100},
+    )
+    stats = _stats(
+        {
+            "player_id": "RB1",
+            "player_name": "Some RB",
+            "position": "RB",
+            "season": 2023,
+            "targets": 50,
+            "receiving_yards": 300.0,
+            "receiving_first_downs": 15,
+        },
+        {
+            "player_id": "WR1",
+            "player_name": "Star WR",
+            "position": "WR",
+            "season": 2023,
+            "targets": 25,
+            "receiving_yards": 250.0,
+            "receiving_first_downs": 12,
+        },
+    )
+    eff = compute_efficiency(routes, stats)
+    assert eff["position"].to_list() == ["WR"]
+
+
+def test_efficiency_sorted_by_yprr_descending():
+    routes = _routes(
+        {"player_id": "WR1", "season": 2023, "routes_proxy": 100},
+        {"player_id": "WR2", "season": 2023, "routes_proxy": 100},
+    )
+    stats = _stats(
+        {
+            "player_id": "WR1",
+            "player_name": "Low YPRR",
+            "position": "WR",
+            "season": 2023,
+            "targets": 20,
+            "receiving_yards": 100.0,
+            "receiving_first_downs": 5,
+        },
+        {
+            "player_id": "WR2",
+            "player_name": "High YPRR",
+            "position": "WR",
+            "season": 2023,
+            "targets": 20,
+            "receiving_yards": 300.0,
+            "receiving_first_downs": 10,
+        },
+    )
+    eff = compute_efficiency(routes, stats)
+    assert eff["player_name"].to_list() == ["High YPRR", "Low YPRR"]

--- a/tests/test_fantasy_efficiency.py
+++ b/tests/test_fantasy_efficiency.py
@@ -12,8 +12,10 @@ from g_nfl.fantasy.projections.efficiency import (
     EFFICIENCY_POSITIONS,
     Z_CLIP,
     _scored_efficiency,
+    _scored_rates,
     apply_efficiency_adjustment,
     blend_efficiency,
+    blend_rates,
     compute_efficiency,
     compute_routes_proxy,
 )
@@ -455,3 +457,81 @@ def test_default_z_strength_is_eight_percent():
 
 def test_efficiency_positions_is_wr_te():
     assert EFFICIENCY_POSITIONS == {"WR", "TE"}
+
+
+# ---------------------------------------------------------------------------
+# _scored_rates / blend_rates (board diagnostic columns: tprr/yprr/fdrr)
+# ---------------------------------------------------------------------------
+
+
+def _routes_with_stats(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "season": pl.Int32,
+            "routes_proxy": pl.UInt32,
+            "targets": pl.Int32,
+            "receiving_yards": pl.Float64,
+            "receiving_first_downs": pl.Int32,
+        },
+    )
+
+
+def test_scored_rates_computes_tprr_yprr_fdrr():
+    raw = _routes_with_stats(
+        {
+            "player_id": "WR1",
+            "season": 2023,
+            "routes_proxy": 100,
+            "targets": 25,
+            "receiving_yards": 250.0,
+            "receiving_first_downs": 12,
+        }
+    )
+    scored = _scored_rates(raw)
+    row = scored.row(0, named=True)
+    assert abs(row["tprr"] - 0.25) < 1e-9
+    assert abs(row["yprr"] - 2.5) < 1e-9
+    assert abs(row["fdrr"] - 0.12) < 1e-9
+
+
+def test_scored_rates_drops_thin_route_sample():
+    raw = _routes_with_stats(
+        {
+            "player_id": "WR1",
+            "season": 2023,
+            "routes_proxy": 30,
+            "targets": 5,
+            "receiving_yards": 40.0,
+            "receiving_first_downs": 2,
+        }
+    )
+    assert len(_scored_rates(raw, min_routes=DEFAULT_MIN_ROUTES)) == 0
+    assert len(_scored_rates(raw, min_routes=0)) == 1
+
+
+def test_blend_rates_recency_weighted():
+    scored = _routes_with_stats(
+        {
+            "player_id": "WR1",
+            "season": 2023,
+            "routes_proxy": 100,
+            "targets": 30,
+            "receiving_yards": 300.0,
+            "receiving_first_downs": 15,
+        },
+        {
+            "player_id": "WR1",
+            "season": 2022,
+            "routes_proxy": 100,
+            "targets": 20,
+            "receiving_yards": 200.0,
+            "receiving_first_downs": 10,
+        },
+    ).pipe(_scored_rates)
+    blended = blend_rates(scored, (0.6, 0.4))
+    row = blended.row(0, named=True)
+    assert abs(row["tprr"] - (0.30 * 0.6 + 0.20 * 0.4)) < 1e-9
+    assert abs(row["yprr"] - (3.0 * 0.6 + 2.0 * 0.4)) < 1e-9
+    assert abs(row["fdrr"] - (0.15 * 0.6 + 0.10 * 0.4)) < 1e-9

--- a/tests/test_fantasy_efficiency.py
+++ b/tests/test_fantasy_efficiency.py
@@ -7,6 +7,13 @@ exercise the pure functions directly.
 import polars as pl
 
 from g_nfl.fantasy.projections.efficiency import (
+    DEFAULT_MIN_ROUTES,
+    DEFAULT_Z_STRENGTH,
+    EFFICIENCY_POSITIONS,
+    Z_CLIP,
+    _scored_efficiency,
+    apply_efficiency_adjustment,
+    blend_efficiency,
     compute_efficiency,
     compute_routes_proxy,
 )
@@ -166,3 +173,285 @@ def test_efficiency_sorted_by_yprr_descending():
     )
     eff = compute_efficiency(routes, stats)
     assert eff["player_name"].to_list() == ["High YPRR", "Low YPRR"]
+
+
+# ---------------------------------------------------------------------------
+# _scored_efficiency / blend_efficiency / apply_efficiency_adjustment
+# (the "z-score quality bump on top of season.py's proj_ppg" path)
+# ---------------------------------------------------------------------------
+
+
+def _raw_inputs(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "player_name": pl.Utf8,
+            "position": pl.Utf8,
+            "season": pl.Int32,
+            "games": pl.Int32,
+            "routes_proxy": pl.UInt32,
+            "fantasy_points": pl.Float64,
+            "fantasy_points_ppr": pl.Float64,
+        },
+    )
+
+
+def test_scored_efficiency_pprr_rate():
+    raw = _raw_inputs(
+        {
+            "player_id": "WR1",
+            "player_name": "Star WR",
+            "position": "WR",
+            "season": 2023,
+            "games": 16,
+            "routes_proxy": 320,
+            "fantasy_points": 160.0,
+            "fantasy_points_ppr": 240.0,
+        }
+    )
+    scored = _scored_efficiency(raw, "ppr")
+    row = scored.row(0, named=True)
+    assert abs(row["pprr"] - 240.0 / 320) < 1e-9
+
+
+def test_scored_efficiency_drops_thin_route_sample():
+    raw = _raw_inputs(
+        {
+            "player_id": "WR1",
+            "player_name": "Thin Sample",
+            "position": "WR",
+            "season": 2023,
+            "games": 2,
+            "routes_proxy": 30,
+            "fantasy_points": 10.0,
+            "fantasy_points_ppr": 15.0,
+        }
+    )
+    assert len(_scored_efficiency(raw, "ppr", min_routes=DEFAULT_MIN_ROUTES)) == 0
+    assert len(_scored_efficiency(raw, "ppr", min_routes=0)) == 1
+
+
+def _scored(*rows: dict) -> pl.DataFrame:
+    """Synthetic already-scored frame (player_id, player_name, position,
+    season, pprr) for blend_efficiency, skipping the routes_proxy/games math.
+    """
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "player_name": pl.Utf8,
+            "position": pl.Utf8,
+            "season": pl.Int32,
+            "pprr": pl.Float64,
+        },
+    )
+
+
+def test_blend_efficiency_zscore_vs_position_peers():
+    """Three WRs, one TE. WR pprr values 0.4/0.5/0.6 -> mean 0.5, pop std
+    sqrt(0.02/3); the TE alone in its position group gets z=0 (zero variance).
+    """
+    scored = _scored(
+        {
+            "player_id": "WR1",
+            "player_name": "Low",
+            "position": "WR",
+            "season": 2023,
+            "pprr": 0.4,
+        },
+        {
+            "player_id": "WR2",
+            "player_name": "Mid",
+            "position": "WR",
+            "season": 2023,
+            "pprr": 0.5,
+        },
+        {
+            "player_id": "WR3",
+            "player_name": "High",
+            "position": "WR",
+            "season": 2023,
+            "pprr": 0.6,
+        },
+        {
+            "player_id": "TE1",
+            "player_name": "Solo TE",
+            "position": "TE",
+            "season": 2023,
+            "pprr": 0.3,
+        },
+    )
+    blended = blend_efficiency(scored, (1.0,))
+    rows = {r["player_id"]: r for r in blended.iter_rows(named=True)}
+    assert abs(rows["WR2"]["pprr_z"] - 0.0) < 1e-9
+    assert rows["WR3"]["pprr_z"] > 0
+    assert rows["WR1"]["pprr_z"] < 0
+    assert abs(rows["WR1"]["pprr_z"]) == abs(rows["WR3"]["pprr_z"])  # symmetric
+    assert rows["TE1"]["pprr_z"] == 0.0  # single TE, zero variance in its group
+
+
+def test_blend_efficiency_zscore_clipped():
+    """An extreme outlier's z is capped at +-Z_CLIP, not left unbounded."""
+    scored = _scored(
+        *[
+            {
+                "player_id": f"WR{i}",
+                "player_name": f"Avg{i}",
+                "position": "WR",
+                "season": 2023,
+                "pprr": 0.5,
+            }
+            for i in range(20)
+        ],
+        {
+            "player_id": "OUTLIER",
+            "player_name": "Outlier",
+            "position": "WR",
+            "season": 2023,
+            "pprr": 5.0,
+        },
+    )
+    blended = blend_efficiency(scored, (1.0,))
+    outlier_z = blended.filter(pl.col("player_id") == "OUTLIER").row(0, named=True)[
+        "pprr_z"
+    ]
+    assert outlier_z == Z_CLIP
+
+
+def _base(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "player_name": pl.Utf8,
+            "position": pl.Utf8,
+            "last_team": pl.Utf8,
+            "n_seasons": pl.UInt32,
+            "proj_ppg": pl.Float64,
+            "proj_points": pl.Float64,
+        },
+    )
+
+
+def _efficiency(*rows: dict) -> pl.DataFrame:
+    return pl.DataFrame(
+        rows,
+        schema={
+            "player_id": pl.Utf8,
+            "player_name": pl.Utf8,
+            "position": pl.Utf8,
+            "n_seasons": pl.UInt32,
+            "pprr_proj": pl.Float64,
+            "pprr_z": pl.Float64,
+        },
+    )
+
+
+def test_adjustment_scales_proj_ppg_by_z():
+    base = _base(
+        {
+            "player_id": "WR1",
+            "player_name": "Star WR",
+            "position": "WR",
+            "last_team": "KC",
+            "n_seasons": 3,
+            "proj_ppg": 10.0,
+            "proj_points": 170.0,
+        }
+    )
+    efficiency = _efficiency(
+        {
+            "player_id": "WR1",
+            "player_name": "Star WR",
+            "position": "WR",
+            "n_seasons": 3,
+            "pprr_proj": 0.05,
+            "pprr_z": 2.0,
+        }
+    )
+    adjusted = apply_efficiency_adjustment(base, efficiency, strength=0.08, games=17)
+    row = adjusted.row(0, named=True)
+    expected_ppg = 10.0 * (1 + 0.08 * 2.0)
+    assert abs(row["proj_ppg"] - expected_ppg) < 1e-9
+    assert abs(row["proj_points"] - expected_ppg * 17) < 1e-9
+
+
+def test_adjustment_strength_zero_keeps_base():
+    base = _base(
+        {
+            "player_id": "WR1",
+            "player_name": "Star WR",
+            "position": "WR",
+            "last_team": "KC",
+            "n_seasons": 3,
+            "proj_ppg": 10.0,
+            "proj_points": 170.0,
+        }
+    )
+    efficiency = _efficiency(
+        {
+            "player_id": "WR1",
+            "player_name": "Star WR",
+            "position": "WR",
+            "n_seasons": 3,
+            "pprr_proj": 0.05,
+            "pprr_z": 2.0,
+        }
+    )
+    adjusted = apply_efficiency_adjustment(base, efficiency, strength=0.0, games=17)
+    assert abs(adjusted.row(0, named=True)["proj_ppg"] - 10.0) < 1e-9
+
+
+def test_adjustment_skips_players_without_efficiency_row():
+    """A player below the routes floor (no efficiency row) keeps base proj_ppg."""
+    base = _base(
+        {
+            "player_id": "WR2",
+            "player_name": "Thin Sample WR",
+            "position": "WR",
+            "last_team": "NE",
+            "n_seasons": 1,
+            "proj_ppg": 5.0,
+            "proj_points": 85.0,
+        }
+    )
+    efficiency = _efficiency()  # empty: no rows for WR2
+    adjusted = apply_efficiency_adjustment(base, efficiency, strength=0.08, games=17)
+    assert abs(adjusted.row(0, named=True)["proj_ppg"] - 5.0) < 1e-9
+
+
+def test_adjustment_skips_non_wr_te_positions():
+    base = _base(
+        {
+            "player_id": "RB1",
+            "player_name": "Some RB",
+            "position": "RB",
+            "last_team": "SF",
+            "n_seasons": 3,
+            "proj_ppg": 12.0,
+            "proj_points": 204.0,
+        }
+    )
+    # Hypothetical efficiency row present (shouldn't happen for RB in practice,
+    # but the position guard must hold regardless).
+    efficiency = _efficiency(
+        {
+            "player_id": "RB1",
+            "player_name": "Some RB",
+            "position": "RB",
+            "n_seasons": 3,
+            "pprr_proj": 0.2,
+            "pprr_z": 2.0,
+        }
+    )
+    adjusted = apply_efficiency_adjustment(base, efficiency, strength=0.08, games=17)
+    assert abs(adjusted.row(0, named=True)["proj_ppg"] - 12.0) < 1e-9
+
+
+def test_default_z_strength_is_eight_percent():
+    assert DEFAULT_Z_STRENGTH == 0.08
+
+
+def test_efficiency_positions_is_wr_te():
+    assert EFFICIENCY_POSITIONS == {"WR", "TE"}

--- a/tests/test_fantasy_season.py
+++ b/tests/test_fantasy_season.py
@@ -9,6 +9,7 @@ import pytest
 
 from g_nfl.fantasy.projections.season import (
     DEFAULT_GAMES,
+    _recency_weighted,
     _scored_ppg,
     blend_projections,
 )
@@ -267,3 +268,27 @@ def test_fb_normalised_to_rb():
     )
     scored = _scored_ppg(normalised, "ppr")
     assert scored.filter(pl.col("player_id") == "FB1")["position"][0] == "RB"
+
+
+# ---------------------------------------------------------------------------
+# _recency_weighted (shared blend primitive, reused by efficiency.py)
+# ---------------------------------------------------------------------------
+
+
+def test_recency_weighted_arbitrary_value_column():
+    """Generic over the value column being blended, not just 'ppg'."""
+    df = pl.DataFrame(
+        {
+            "player_id": ["A", "A", "B"],
+            "season": [2024, 2023, 2024],
+            "rate": [10.0, 20.0, 5.0],
+        },
+        schema={"player_id": pl.Utf8, "season": pl.Int32, "rate": pl.Float64},
+    )
+    result = _recency_weighted(df, "rate", (0.6, 0.3, 0.1))
+    a_row = result.filter(pl.col("player_id") == "A").row(0, named=True)
+    b_row = result.filter(pl.col("player_id") == "B").row(0, named=True)
+    assert abs(a_row["blended_rate"] - (10.0 * 0.6 + 20.0 * 0.3) / 0.9) < 1e-9
+    assert a_row["n_seasons"] == 2
+    assert abs(b_row["blended_rate"] - 5.0) < 1e-9
+    assert b_row["n_seasons"] == 1


### PR DESCRIPTION
## Summary
- Routes-run proxy from `nflreadpy.load_participation` (accurate for WR, biased high for in-line TEs, unusable for RB — dropped)
- `efficiency.py`: `load_efficiency()` -> per-player-season TPRR/YPRR/1DRR for WR/TE
- PAR board: recency-blended TPRR/YPRR/1DRR diagnostic columns (`-` for QB/RB) via `attach_efficiency_rates()`
- Z-score ppg-adjustment path (`apply_efficiency_adjustment`) built + tested but left **off by default** — 2024 backtest showed worse MAE, mixed hit-rate. Documented as unvalidated, revisit with proper walk-forward backtest.
- Ranking math (proj_ppg/ppgar) untouched — confirmed byte-identical board output pre/post, diagnostics only.

## Test plan
- [x] 130/130 tests green
- [x] lint clean
- [x] live board run confirms ranking unchanged, columns populated

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)