### PR TITLE
feat(ml): opponent-adjusted team ratings — rejected lever, infra kept (#37)

### DIFF
--- a/src/g_nfl/ml/evaluate.py
+++ b/src/g_nfl/ml/evaluate.py
@@ -275,6 +275,9 @@ def backtest(
     qb_history: int = 3,
     continuity: bool = False,
     ml_odds: bool = False,
+    opp_adjust: bool = False,
+    opp_lambda: float = 10.0,
+    opp_prior_weight: float = 0.3,
     cache_dir: Path | str = DEFAULT_CACHE_DIR,
     refresh: bool = False,
 ) -> tuple[pl.DataFrame, str]:
@@ -284,10 +287,16 @@ def backtest(
     ``qb_ctx`` loads ``qb_history`` extra contiguous seasons of pbp before
     the earliest eval season to warm the per-QB EWMA; the matrix rows stay
     eval-season only (schedule is loaded for ``seasons`` alone), so the
-    training set is identical to the baseline — a clean A/B.
+    training set is identical to the baseline — a clean A/B. ``opp_adjust``
+    needs at least 1 prior season of pbp so eval-season week-1 ratings have
+    a prior; it shares this extra-pbp-history mechanism with ``qb_ctx``
+    rather than loading its own copy.
     """
+    extra_history = max(qb_history if qb_ctx else 0, 1 if opp_adjust else 0)
     pbp_seasons = (
-        list(range(min(seasons) - qb_history, max(seasons) + 1)) if qb_ctx else seasons
+        list(range(min(seasons) - extra_history, max(seasons) + 1))
+        if extra_history
+        else seasons
     )
     pbp = load_pbp(pbp_seasons, cache_dir=cache_dir, refresh=refresh)
     schedule = load_schedule(seasons, cache_dir=cache_dir, refresh=refresh)
@@ -327,6 +336,9 @@ def backtest(
         snaps=snaps,
         ml_odds=ml_odds,
         ml_margins=ml_margins,
+        opp_adjust=opp_adjust,
+        opp_lambda=opp_lambda,
+        opp_prior_weight=opp_prior_weight,
     ).filter(pl.col("result").is_not_null())
 
     fs = get_feature_set(feature_set)
@@ -352,6 +364,9 @@ def backtest(
             "qb_ctx": qb_ctx,
             "continuity": continuity,
             "ml_odds": ml_odds,
+            "opp_adjust": opp_adjust,
+            "opp_lambda": opp_lambda,
+            "opp_prior_weight": opp_prior_weight,
         },
     )
     return preds, report
@@ -410,6 +425,23 @@ def main(argv: list[str] | None = None) -> None:
         help="L4 moneyline-implied spread + divergence from posted line",
     )
     parser.add_argument(
+        "--opp-adjust",
+        action="store_true",
+        help="L4 opponent-adjusted offense/defense ratings (weighted ridge)",
+    )
+    parser.add_argument(
+        "--opp-lambda",
+        type=float,
+        default=10.0,
+        help="ridge penalty for opponent-adjusted ratings",
+    )
+    parser.add_argument(
+        "--opp-prior-weight",
+        type=float,
+        default=0.3,
+        help="sample weight on prior-season games in opponent-adjusted ratings",
+    )
+    parser.add_argument(
         "--output", type=Path, help="also write the markdown report to this path"
     )
     parser.add_argument(
@@ -436,6 +468,9 @@ def main(argv: list[str] | None = None) -> None:
         qb_ctx=args.qb,
         continuity=args.continuity,
         ml_odds=args.ml_odds,
+        opp_adjust=args.opp_adjust,
+        opp_lambda=args.opp_lambda,
+        opp_prior_weight=args.opp_prior_weight,
         refresh=args.refresh,
     )
     print(report)
@@ -471,6 +506,9 @@ def main(argv: list[str] | None = None) -> None:
                     "qb_ctx": args.qb,
                     "continuity": args.continuity,
                     "ml_odds": args.ml_odds,
+                    "opp_adjust": args.opp_adjust,
+                    "opp_lambda": args.opp_lambda,
+                    "opp_prior_weight": args.opp_prior_weight,
                     **resolved_params,
                 }
             )

--- a/src/g_nfl/ml/features/__init__.py
+++ b/src/g_nfl/ml/features/__init__.py
@@ -16,6 +16,7 @@ from g_nfl.ml.features.context import add_schedule_context
 from g_nfl.ml.features.continuity import add_continuity
 from g_nfl.ml.features.injuries import add_injuries
 from g_nfl.ml.features.matrix import build_game_matrix
+from g_nfl.ml.features.opponent import add_opponent_ratings, team_games_frame
 from g_nfl.ml.features.plays import play_features
 from g_nfl.ml.features.qb import add_qb_context
 from g_nfl.ml.features.team_week import team_week_stats
@@ -40,6 +41,9 @@ def build_features(
     snaps: pl.DataFrame | None = None,
     ml_odds: bool = False,
     ml_margins: np.ndarray | None = None,
+    opp_adjust: bool = False,
+    opp_lambda: float = 10.0,
+    opp_prior_weight: float = 0.3,
 ) -> pl.DataFrame:
     """Full pipeline: raw pbp + schedule -> game-level training matrix.
 
@@ -62,6 +66,10 @@ def build_features(
     ``ml_margins`` calibrates the implied-spread margin distribution from a
     deep, strictly-prior reference (passed by the caller); None falls back to
     self-calibration on the matrix's own completed games.
+    ``opp_adjust`` (L4) attaches opponent-adjusted offense/defense ratings
+    per stat (see `opponent.add_opponent_ratings`), fit strictly on weeks
+    before the game plus the prior season; requires ``pbp`` to carry prior-
+    season lookback to warm week-1 ratings (same mechanism as ``qb_ctx``).
     """
     reg_schedule = schedule.filter(pl.col("game_type") == "REG")
     plays = play_features(pbp, wp_filter, epa_splits=epa_splits)
@@ -91,4 +99,8 @@ def build_features(
         matrix = add_continuity(matrix, snaps)
     if ml_odds:
         matrix = add_ml_odds(matrix, reg_schedule, margins=ml_margins)
+    if opp_adjust:
+        matrix = add_opponent_ratings(
+            matrix, team_games_frame(plays), opp_lambda, opp_prior_weight
+        )
     return matrix

--- a/src/g_nfl/ml/features/opponent.py
+++ b/src/g_nfl/ml/features/opponent.py
@@ -1,0 +1,176 @@
+"""Opponent-adjusted team ratings via weighted ridge regression.
+
+All other team stats in the pipeline are raw: a team's EPA/success/CPOE
+mean is unadjusted for who it played. This module fits a per-(season,
+week) two-way (offense/defense) ridge regression at team-game grain —
+the standard "strength of schedule" adjustment — so a team's rating
+reflects performance relative to the opponents it actually faced.
+
+Anti-leak contract (hard requirement): ratings for game week ``w`` are
+fit on strictly-prior data only — weeks ``< w`` of the same season, plus
+the *entire* prior season at a lower sample weight (so week-1 of a
+season isn't cold). Nothing from week ``w`` or later ever enters the
+fit, so joining the (season, week) rating onto that week's matrix row
+needs no additional lag (same pattern as `injuries.add_injuries`). Off
+by default (see `build_features` ``opp_adjust``).
+"""
+
+import numpy as np
+import polars as pl
+
+STATS = ["epa", "success", "cpoe"]
+
+
+def team_games_frame(plays: pl.DataFrame) -> pl.DataFrame:
+    """One row per (season, week, posteam, defteam) with null-safe stat means.
+
+    ``plays`` is the filtered play-level frame (`plays.play_features`);
+    cpoe is null on non-pass plays so a team-game with no dropbacks gets
+    a null cpoe mean.
+    """
+    return plays.group_by("season", "week", "posteam", "defteam").agg(
+        [pl.col(stat).mean().alias(stat) for stat in STATS]
+    )
+
+
+def fit_opponent_ratings(
+    team_games: pl.DataFrame,
+    stat: str,
+    lam: float,
+    prior_weight: float,
+    season: int,
+    week: int,
+) -> pl.DataFrame:
+    """Weighted ridge fit of per-team offense/defense ratings for one stat.
+
+    Training rows: current-``season`` team-games with ``week <= week - 1``
+    at sample weight 1.0, plus every ``season - 1`` team-game at weight
+    ``prior_weight`` — nothing else. y is the team-game ``stat`` mean,
+    centered on its weighted mean first, so ratings sit relative to the
+    (weighted) league average and the intercept isn't penalized. Returns
+    one row per team with ``off_rating``/``def_rating``; a team with no
+    rows in the training window simply isn't in the output (callers treat
+    that as league average, 0).
+    """
+    cur = team_games.filter(
+        (pl.col("season") == season)
+        & (pl.col("week") <= week - 1)
+        & pl.col(stat).is_not_null()
+    ).with_columns(_w=pl.lit(1.0))
+    prior = team_games.filter(
+        (pl.col("season") == season - 1) & pl.col(stat).is_not_null()
+    ).with_columns(_w=pl.lit(float(prior_weight)))
+    rows = pl.concat([cur, prior], how="vertical_relaxed")
+
+    empty = pl.DataFrame(
+        schema={"team": pl.Utf8, "off_rating": pl.Float64, "def_rating": pl.Float64}
+    )
+    if rows.height == 0:
+        return empty
+
+    teams = sorted(set(rows["posteam"].to_list()) | set(rows["defteam"].to_list()))
+    idx = {t: i for i, t in enumerate(teams)}
+    n_teams = len(teams)
+    n = rows.height
+
+    off_idx = np.array([idx[t] for t in rows["posteam"].to_list()])
+    def_idx = np.array([idx[t] for t in rows["defteam"].to_list()])
+    X = np.zeros((n, 2 * n_teams))
+    X[np.arange(n), off_idx] = 1.0
+    X[np.arange(n), n_teams + def_idx] = 1.0
+
+    y = rows[stat].to_numpy().astype(float)
+    w = rows["_w"].to_numpy().astype(float)
+    if w.sum() == 0:
+        return empty
+
+    y_centered = y - np.sum(w * y) / np.sum(w)
+    xtw = X.T * w  # (2T, n), each row scaled by its sample weight
+    a = xtw @ X + lam * np.eye(2 * n_teams)
+    b = xtw @ y_centered
+    beta = np.linalg.solve(a, b)
+
+    return pl.DataFrame(
+        {
+            "team": teams,
+            "off_rating": beta[:n_teams],
+            "def_rating": beta[n_teams:],
+        }
+    )
+
+
+def add_opponent_ratings(
+    matrix: pl.DataFrame,
+    team_games: pl.DataFrame,
+    lam: float,
+    prior_weight: float,
+) -> pl.DataFrame:
+    """Join per-(season, week) opponent-adjusted ratings onto the matrix.
+
+    Adds 12 cols (``{home,away}_{epa,success,cpoe}_adj_{off,def}``) plus
+    ``adj_rating_diff``. Ratings for a game's own week only use strictly
+    earlier weeks (+ prior season) by construction (see
+    `fit_opponent_ratings`), so this join needs no extra lag. Weeks with
+    no usable training data at all (e.g. week 1 of the earliest loaded
+    season with no prior season loaded) get null ratings for every team;
+    weeks with data get 0 (league average) for any team absent from the
+    fit (cold start / relocation).
+    """
+    all_teams = (
+        pl.concat(
+            [
+                team_games.select(pl.col("posteam").alias("team")),
+                team_games.select(pl.col("defteam").alias("team")),
+            ]
+        )
+        .unique()
+        .sort("team")
+    )
+
+    pairs = matrix.select("season", "week").unique().sort("season", "week")
+    week_frames = []
+    for season, week in pairs.iter_rows():
+        stat_frames = []
+        for stat in STATS:
+            fit = fit_opponent_ratings(
+                team_games, stat, lam, prior_weight, season, week
+            )
+            if fit.height == 0:
+                joined = all_teams.with_columns(
+                    pl.lit(None, dtype=pl.Float64).alias("off_rating"),
+                    pl.lit(None, dtype=pl.Float64).alias("def_rating"),
+                )
+            else:
+                joined = all_teams.join(fit, on="team", how="left").with_columns(
+                    pl.col("off_rating", "def_rating").fill_null(0.0)
+                )
+            stat_frames.append(
+                joined.rename(
+                    {"off_rating": f"{stat}_adj_off", "def_rating": f"{stat}_adj_def"}
+                )
+            )
+        combined = stat_frames[0]
+        for f in stat_frames[1:]:
+            combined = combined.join(f, on="team")
+        week_frames.append(
+            combined.with_columns(season=pl.lit(season), week=pl.lit(week))
+        )
+
+    ratings = pl.concat(week_frames).with_columns(
+        pl.col("season").cast(matrix.schema["season"]),
+        pl.col("week").cast(matrix.schema["week"]),
+    )
+    adj_cols = [f"{stat}_adj_{side}" for stat in STATS for side in ("off", "def")]
+    away = ratings.rename({"team": "away_team", **{c: f"away_{c}" for c in adj_cols}})
+    home = ratings.rename({"team": "home_team", **{c: f"home_{c}" for c in adj_cols}})
+    return (
+        matrix.join(away, on=["away_team", "season", "week"], how="left")
+        .join(home, on=["home_team", "season", "week"], how="left")
+        .with_columns(
+            # def_rating is EPA *allowed* (higher = worse defense), so the
+            # home margin gains from the away defense's rating and loses to
+            # its own defense's: (home_off + away_def) - (away_off + home_def)
+            adj_rating_diff=(pl.col("home_epa_adj_off") + pl.col("away_epa_adj_def"))
+            - (pl.col("away_epa_adj_off") + pl.col("home_epa_adj_def"))
+        )
+    )

--- a/src/g_nfl/ml/features/registry.py
+++ b/src/g_nfl/ml/features/registry.py
@@ -5,6 +5,7 @@ persisted with trained models (#10/#12) so predictions rebuild the
 exact same inputs.
 """
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -37,7 +38,65 @@ V1_TEAM = FeatureSet(
     selector=_all_team_stat_cols,
 )
 
-FEATURE_SETS: dict[str, FeatureSet] = {fs.name: fs for fs in [V1_TEAM]}
+# L2 finding (notes/modelling/l1-feature-importance.md): the full stat soup
+# is flat and redundant. The lean core keeps just the rate stats that
+# actually carry gain, both home/away, offense/defense, season + rolling.
+_LEAN_STEMS = [
+    "epa_mean",
+    "success_mean",
+    "cpoe_mean",
+    "pass_oe_mean",
+    "sack_mean",
+    "first_down_mean",
+]
+
+
+def _adj_cols(matrix: pl.DataFrame) -> list[str]:
+    """Opponent-adjustment columns (`opponent.add_opponent_ratings`):
+    the 12 `_adj_` off/def rating cols plus `adj_rating_diff`."""
+    cols = [c for c in matrix.columns if "_adj_" in c]
+    if "adj_rating_diff" in matrix.columns:
+        cols.append("adj_rating_diff")
+    if not cols:
+        raise ValueError(
+            "no opponent-adjustment columns found in matrix; build it with "
+            "opp_adjust=True (build_features/backtest) before using this "
+            "feature set"
+        )
+    return cols
+
+
+def _adj_lean_cols(matrix: pl.DataFrame) -> list[str]:
+    """Adj cols plus a lean home/away, season/rolling, off/def core of the
+    top rate stats from the L1 importance findings, in place of the full
+    stat soup (`_LEAN_STEMS`)."""
+    stem_pattern = re.compile(
+        r"^(?:home|away)_(?:" + "|".join(re.escape(s) for s in _LEAN_STEMS) + r")"
+        r"(?:_def)?_(?:season|last_\d+w)$"
+    )
+    lean = [c for c in matrix.columns if stem_pattern.match(c)]
+    return _adj_cols(matrix) + lean
+
+
+V2_ADJ_ONLY = FeatureSet(
+    name="v2_adj_only",
+    description="Just the opponent-adjusted off/def ratings (13 cols).",
+    selector=_adj_cols,
+)
+
+V2_ADJ_LEAN = FeatureSet(
+    name="v2_adj_lean",
+    description=(
+        "Opponent-adjusted ratings plus a lean core of top rate features "
+        "(epa/success/cpoe/pass_oe/sack/first_down mean, season + rolling, "
+        "off + def), replacing the full v1_team stat soup."
+    ),
+    selector=_adj_lean_cols,
+)
+
+FEATURE_SETS: dict[str, FeatureSet] = {
+    fs.name: fs for fs in [V1_TEAM, V2_ADJ_ONLY, V2_ADJ_LEAN]
+}
 
 
 def get_feature_set(name: str) -> FeatureSet:

--- a/tests/test_ml_features.py
+++ b/tests/test_ml_features.py
@@ -8,7 +8,12 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from g_nfl.ml.features import build_features
 from g_nfl.ml.features.carryover import carryover_blend
 from g_nfl.ml.features.matrix import META_COLS, build_game_matrix
-from g_nfl.ml.features.opponent import STATS, fit_opponent_ratings, team_games_frame
+from g_nfl.ml.features.opponent import (
+    STATS,
+    add_opponent_ratings,
+    fit_opponent_ratings,
+    team_games_frame,
+)
 from g_nfl.ml.features.plays import (
     EPA_SPLIT_COLS,
     HAVOC_COLS,
@@ -605,3 +610,47 @@ def test_v1_team_feature_set(matrix: pl.DataFrame):
 def test_unknown_feature_set_raises():
     with pytest.raises(KeyError, match="unknown feature set"):
         get_feature_set("nope")
+
+
+@pytest.fixture(scope="module")
+def adj_matrix(windowed: pl.DataFrame, reg_schedule: pl.DataFrame, plays: pl.DataFrame):
+    matrix = build_game_matrix(windowed, reg_schedule)
+    return add_opponent_ratings(
+        matrix, team_games_frame(plays), lam=10.0, prior_weight=0.3
+    )
+
+
+def test_v2_adj_only_feature_set(adj_matrix: pl.DataFrame):
+    feature_cols = get_feature_set("v2_adj_only").columns(adj_matrix)
+    expected = {
+        f"{side}_{stat}_adj_{part}"
+        for side in ("home", "away")
+        for stat in STATS
+        for part in ("off", "def")
+    } | {"adj_rating_diff"}
+    assert set(feature_cols) == expected
+
+
+def test_v2_adj_only_errors_without_opp_adjust(matrix: pl.DataFrame):
+    with pytest.raises(ValueError, match="opp_adjust"):
+        get_feature_set("v2_adj_only").columns(matrix)
+
+
+def test_v2_adj_lean_feature_set(adj_matrix: pl.DataFrame):
+    feature_cols = get_feature_set("v2_adj_lean").columns(adj_matrix)
+    adj_cols = set(get_feature_set("v2_adj_only").columns(adj_matrix))
+    assert adj_cols <= set(feature_cols)
+    lean_only = set(feature_cols) - adj_cols
+    assert lean_only  # picked up some rate-stat core cols too
+    stems = [
+        "epa_mean",
+        "success_mean",
+        "cpoe_mean",
+        "pass_oe_mean",
+        "sack_mean",
+        "first_down_mean",
+    ]
+    for c in lean_only:
+        assert any(stem in c for stem in stems)
+        assert c.startswith(("home_", "away_"))
+        assert c.endswith("_season") or "_last_" in c

--- a/tests/test_ml_features.py
+++ b/tests/test_ml_features.py
@@ -8,6 +8,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from g_nfl.ml.features import build_features
 from g_nfl.ml.features.carryover import carryover_blend
 from g_nfl.ml.features.matrix import META_COLS, build_game_matrix
+from g_nfl.ml.features.opponent import STATS, fit_opponent_ratings, team_games_frame
 from g_nfl.ml.features.plays import (
     EPA_SPLIT_COLS,
     HAVOC_COLS,
@@ -371,6 +372,12 @@ def test_future_weeks_do_not_leak(
     pert_c = build_features(perturbed, schedule_sample, carryover_k=2.0)
     assert_frame_equal(base_c.sort("game_id"), pert_c.sort("game_id"))
 
+    # opp_adjust mode too: week-w ratings only ever use weeks < w, so
+    # perturbing week 5 must not change any row's opponent-adjusted cols
+    base_o = build_features(pbp_sample, schedule_sample, opp_adjust=True)
+    pert_o = build_features(perturbed, schedule_sample, opp_adjust=True)
+    assert_frame_equal(base_o.sort("game_id"), pert_o.sort("game_id"))
+
 
 # ---- L3 injuries ----
 
@@ -450,6 +457,139 @@ def test_schedule_context_cols_and_values(
         exp=pl.col("home_rest") - pl.col("away_rest")
     )
     assert (chk["rest_diff"] == chk["exp"]).all()
+
+
+# ---- L4 opponent-adjusted ratings ----
+
+
+def _team_game(
+    posteam: str, defteam: str, week: int, epa: float, season: int = 2023
+) -> tuple:
+    return (season, week, posteam, defteam, epa)
+
+
+def _synthetic_team_games(season: int = 2023) -> pl.DataFrame:
+    """4-team league where A and B have identical raw offensive epa, but
+    A's games came against a strong defense (D) and B's against a weak
+    one (C) — so an opponent-adjusted rating should separate them even
+    though the raw stat cannot. Extra rows (D vs A/C, C vs B) link the
+    two schedule clusters together without touching A/B's own raw mean
+    (computed only from A/B's *own* posteam rows)."""
+    rows = [
+        _team_game("A", "D", 1, 1.0, season),
+        _team_game("A", "D", 2, 1.0, season),
+        _team_game("B", "C", 1, 1.0, season),
+        _team_game("B", "C", 2, 1.0, season),
+        _team_game("D", "A", 1, 0.0, season),
+        _team_game("C", "B", 1, 0.0, season),
+        _team_game("C", "D", 1, -1.0, season),
+        _team_game("D", "C", 1, 1.0, season),
+    ]
+    return pl.DataFrame(
+        rows, schema=["season", "week", "posteam", "defteam", "epa"], orient="row"
+    )
+
+
+def test_opponent_ratings_adjust_for_strength_of_schedule():
+    team_games = _synthetic_team_games()
+
+    raw = team_games.group_by("posteam").agg(pl.col("epa").mean())
+    raw_a = raw.filter(pl.col("posteam") == "A")["epa"][0]
+    raw_b = raw.filter(pl.col("posteam") == "B")["epa"][0]
+    assert raw_a == pytest.approx(raw_b)  # raw stat can't tell them apart
+
+    fit = fit_opponent_ratings(
+        team_games, "epa", lam=1.0, prior_weight=0.0, season=2023, week=5
+    )
+    off_a = fit.filter(pl.col("team") == "A")["off_rating"][0]
+    off_b = fit.filter(pl.col("team") == "B")["off_rating"][0]
+    assert off_a > off_b  # adjustment reveals A faced the tougher schedule
+
+
+def test_opponent_ratings_shrink_toward_zero_with_large_lambda():
+    team_games = _synthetic_team_games()
+    loose = fit_opponent_ratings(
+        team_games, "epa", lam=0.1, prior_weight=0.0, season=2023, week=5
+    )
+    tight = fit_opponent_ratings(
+        team_games, "epa", lam=1e6, prior_weight=0.0, season=2023, week=5
+    )
+    loose_mag = loose["off_rating"].abs().sum()
+    tight_mag = tight["off_rating"].abs().sum()
+    assert tight_mag < loose_mag
+    assert tight_mag == pytest.approx(0.0, abs=1e-3)
+
+
+def test_opponent_ratings_prior_weight():
+    prior_games = _synthetic_team_games(season=2022)
+
+    # prior_weight=0 -> nothing to fit for week 1 of a fresh season (no
+    # current-season rows exist yet, week <= week - 1 == 0)
+    no_prior = fit_opponent_ratings(
+        prior_games, "epa", lam=1.0, prior_weight=0.0, season=2023, week=1
+    )
+    assert no_prior.height == 0
+
+    # prior_weight > 0 -> week-1 ratings are nonzero and reflect the prior
+    # season's strength-of-schedule-adjusted gap between A and B
+    with_prior = fit_opponent_ratings(
+        prior_games, "epa", lam=1.0, prior_weight=0.5, season=2023, week=1
+    )
+    assert with_prior.height > 0
+    off_a = with_prior.filter(pl.col("team") == "A")["off_rating"][0]
+    off_b = with_prior.filter(pl.col("team") == "B")["off_rating"][0]
+    assert off_a != pytest.approx(0.0)
+    assert off_a > off_b
+
+
+def test_opponent_ratings_prior_season_affects_week1_no_leak(
+    pbp_sample: pl.DataFrame, schedule_sample: pl.DataFrame
+):
+    """Mirrors the qb_ctx/carryover anti-leak style: mutating the *prior*
+    season is allowed to change week-1 ratings (it's legitimate input),
+    but week 1 stays null without any prior season loaded at all."""
+    no_prior = build_features(pbp_sample, schedule_sample, opp_adjust=True)
+    week1 = no_prior.filter(pl.col("week") == 1)
+    assert week1["home_epa_adj_off"].null_count() == week1.height
+
+    prior = pbp_sample.with_columns(
+        pl.lit(2022).cast(pbp_sample.schema["season"]).alias("season")
+    )
+    combined = pl.concat([prior, pbp_sample], how="vertical_relaxed")
+    base = build_features(combined, schedule_sample, opp_adjust=True)
+    base_week1 = base.filter(pl.col("week") == 1)
+    assert base_week1["home_epa_adj_off"].null_count() == 0  # prior warms week 1
+
+    perturbed_prior = prior.with_columns((pl.col("epa") * 100 + 7).alias("epa"))
+    combined_pert = pl.concat([perturbed_prior, pbp_sample], how="vertical_relaxed")
+    pert = build_features(combined_pert, schedule_sample, opp_adjust=True)
+    pert_week1 = pert.filter(pl.col("week") == 1)
+
+    assert not base_week1.select("home_epa_adj_off", "away_epa_adj_off").equals(
+        pert_week1.select("home_epa_adj_off", "away_epa_adj_off")
+    )
+
+
+def test_opp_adjust_toggle(pbp_sample: pl.DataFrame, schedule_sample: pl.DataFrame):
+    base = build_features(pbp_sample, schedule_sample)
+    out = build_features(pbp_sample, schedule_sample, opp_adjust=True)
+
+    added = set(out.columns) - set(base.columns)
+    expected = {
+        f"{side}_{stat}_adj_{part}"
+        for side in ("home", "away")
+        for stat in STATS
+        for part in ("off", "def")
+    } | {"adj_rating_diff"}
+    assert added == expected
+    assert out.height == base.height  # join on (team, season, week) drops nothing
+
+
+def test_team_games_frame_grain(plays: pl.DataFrame):
+    tg = team_games_frame(plays)
+    keys = tg.select("season", "week", "posteam", "defteam")
+    assert keys.height == keys.unique().height
+    assert set(STATS) <= set(tg.columns)
 
 
 # ---- registry ----


### PR DESCRIPTION
## Summary

Opponent-adjusted team ratings via two-way weighted ridge at team-game grain (#37), plus lean `v2_adj_only`/`v2_adj_lean` feature sets. The lever was **rejected at the one-shot 2024/25 holdout gate** (full-set 46.6%, guard broken) after passing tune — full arc and lessons in `notes/opponent-adjusted-ratings.md` and the issue thread.

Merging as off-by-default infra, per the project pattern for rejected levers (qb_ctx, continuity, injuries): `opp_adjust=False` default keeps every existing path byte-identical; 139 tests green incl. anti-leak both directions.

## Changes

- `features/opponent.py` — weighted ridge (off/def one-hot, prior-season pseudo-games at `opp_prior_weight`), `{stat}_adj_{off,def}` + `adj_rating_diff` at matrix stage
- Threading: `build_features` / `evaluate.backtest` / CLI `--opp-adjust --opp-lambda --opp-prior-weight` / MLflow params; shares the qb_ctx prior-pbp-history mechanism
- Registry: `v2_adj_only` (13 adj cols), `v2_adj_lean` (adj + 48 top-L1 rates)
- Tests: 9 new (ridge correctness on synthetic fixture, shrinkage, prior weight, anti-leak, toggle, registry sets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)