### PR TITLE
fix(ml): align injuries schema across seasons (#42)

### DIFF
--- a/src/g_nfl/ml/data.py
+++ b/src/g_nfl/ml/data.py
@@ -76,10 +76,15 @@ def load_injuries(
     healthy. Key columns: gsis_id, team, week, position, report_status
     (Out/Doubtful/Questionable, null = listed but no game designation),
     practice_status.
+
+    Schema drifts across seasons (2025 adds `season_type`, drops
+    `date_modified`; `game_type` is present in both) so this concats
+    diagonally by column name instead of position — extra/missing columns
+    null-fill rather than erroring.
     """
     return pl.concat(
         [_load_cached("injuries", s, Path(cache_dir), refresh) for s in seasons],
-        how="vertical_relaxed",
+        how="diagonal_relaxed",
     )
 
 

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -55,3 +55,39 @@ def test_load_schedule_caches(tmp_path, monkeypatch, schedule_sample):
 def test_unknown_dataset_raises():
     with pytest.raises(ValueError, match="unknown dataset"):
         data._fetch("nope", 2023)
+
+
+def test_load_injuries_handles_schema_drift(tmp_path, monkeypatch):
+    """2024 has date_modified/game_type, no season_type; 2025 has
+    season_type/game_type, no date_modified (#42)."""
+    injuries_2024 = pl.DataFrame(
+        {
+            "season": [2024],
+            "game_type": ["REG"],
+            "team": ["KC"],
+            "week": [1],
+            "gsis_id": ["00-1"],
+            "date_modified": ["2024-09-01"],
+        }
+    )
+    injuries_2025 = pl.DataFrame(
+        {
+            "season": [2025],
+            "season_type": ["REG"],
+            "game_type": ["REG"],
+            "team": ["BUF"],
+            "week": [1],
+            "gsis_id": ["00-2"],
+        }
+    )
+    samples = {2024: injuries_2024, 2025: injuries_2025}
+
+    def fake_fetch(dataset: str, season: int) -> pl.DataFrame:
+        return samples[season]
+
+    monkeypatch.setattr(data, "_fetch", fake_fetch)
+
+    out = data.load_injuries([2024, 2025], cache_dir=tmp_path)
+    assert out.height == 2
+    assert out["game_type"].null_count() == 0
+    assert set(out["game_type"].unique().to_list()) == {"REG"}


### PR DESCRIPTION
Closes #42.

`load_injuries([2024, 2025])` failed in `pl.concat`: schema drift across seasons. Root cause differs from the issue premise — 2025 **keeps** `game_type` (same DIV/CON/REG/WC/SB vocab, 0 nulls); the error was positional: `vertical_relaxed` matches columns by index, and the new `season_type` column at position 2 shifted `game_type`, producing the name-mismatch error. Only real diffs: `date_modified` (2024-only) and `season_type` (2025-only).

**Fix**: concat `how="diagonal_relaxed"` — aligns by column name, null-fills extra/missing columns. No derivation needed; downstream `game_type == "REG"` filters unaffected.

**Verification**:
- New test `test_load_injuries_handles_schema_drift` (mocked 2024/2025 schemas, no network)
- Full suite: 131 passed
- Smoke: `load_injuries([2024, 2025])` → (12283, 17), `game_type` null_count 0

Note: per #39, this does not license re-running the 2025 holdout — look is spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)