### PR TITLE
fix(utils): resolve PROJECT_DIR from __file__, not cwd (#51)

### DIFF
--- a/src/g_nfl/archive/homers.py
+++ b/src/g_nfl/archive/homers.py
@@ -6,7 +6,7 @@ import plotly.express as px
 from g_nfl.utils.paths import HOMERS_PATH
 from src import old_utils
 
-PROCESSED_FILE_PATH = f"{HOMERS_PATH}/homers-processed.pkl"
+PROCESSED_FILE_PATH = HOMERS_PATH / "homers-processed.pkl"
 
 
 def process_picks(df: pd.DataFrame, week, season) -> pd.DataFrame:

--- a/src/g_nfl/archive/old_utils.py
+++ b/src/g_nfl/archive/old_utils.py
@@ -1,4 +1,3 @@
-import os
 import re
 from collections import defaultdict
 
@@ -79,8 +78,7 @@ def download_team_pngs():
     base_url = "https://a.espncdn.com/i/teamlogos/nfl/500/"
 
     # Create the local directory if it doesn't exist
-    if not os.path.exists(LOGO_PATH):
-        os.makedirs(LOGO_PATH)
+    LOGO_PATH.mkdir(parents=True, exist_ok=True)
 
     # Iterate through the list of teams, download logos, and save them locally
     for team in nfl_teams:

--- a/src/g_nfl/archive/scrapers.py
+++ b/src/g_nfl/archive/scrapers.py
@@ -1,4 +1,3 @@
-import os
 import re
 from io import BytesIO
 
@@ -48,8 +47,8 @@ def scrape_inpredictable(week: int, season: int) -> None:
     )
 
     # dont overwrite an existing file
-    file_path = f"{INPREDICABLE_PATH}/inpredictable-{season}-wk{week}.csv"
-    if os.path.isfile(file_path):
+    file_path = INPREDICABLE_PATH / f"inpredictable-{season}-wk{week}.csv"
+    if file_path.exists():
         print(f"{file_path} exists!")
     else:
         # write the file to the correct path
@@ -69,8 +68,8 @@ def scrape_unabated(week: int, season: int) -> None:
     df = utils.clean_df_columns(df)
     assert df.shape[0] == 32
     # dont overwrite an existing file
-    file_path = f"{UNABATED_PATH}/unabated-{season}-wk{week}.csv"
-    if os.path.isfile(file_path):
+    file_path = UNABATED_PATH / f"unabated-{season}-wk{week}.csv"
+    if file_path.exists():
         print(f"{file_path} exists!")
     else:
         # write the file to the correct path
@@ -105,8 +104,8 @@ def scrape_espn(week: int, season: int) -> None:
     assert df.shape[0] == 32
 
     # dont overwrite an existing file
-    file_path = f"{ESPN_PATH}/espn-{season}-wk{week}.csv"
-    if os.path.isfile(file_path):
+    file_path = ESPN_PATH / f"espn-{season}-wk{week}.csv"
+    if file_path.exists():
         print(f"{file_path} exists!")
     else:
         # write the file to the correct path
@@ -136,8 +135,8 @@ def scrape_nfelo(week: int, season: int) -> None:
     assert df.shape[0] == 32
 
     # dont overwrite an existing file
-    file_path = f"{NFELO_PATH}/nfelo-{season}-wk{week}.csv"
-    if os.path.isfile(file_path):
+    file_path = NFELO_PATH / f"nfelo-{season}-wk{week}.csv"
+    if file_path.exists():
         print(f"{file_path} exists!")
     else:
         # write the file to the correct path

--- a/src/g_nfl/utils/logos.py
+++ b/src/g_nfl/utils/logos.py
@@ -1,4 +1,3 @@
-import os
 import urllib.request
 
 import nflreadpy as nfl
@@ -19,9 +18,9 @@ def get_logo_url(team: str, size: int = 25):
 
 def fetch_logos():
     # if the path to the logos directory does not exist, create it
-    if not os.path.exists(LOGO_PATH):
+    if not LOGO_PATH.exists():
         print("fetching team logos...")
-        os.makedirs(LOGO_PATH, exist_ok=True)
+        LOGO_PATH.mkdir(parents=True, exist_ok=True)
         logos = nfl.load_teams().select(["team_abbr", "team_logo_espn"])
 
         # get the logos for each team and store them to tif files in the logo path directory "<team>.tif"

--- a/src/g_nfl/utils/paths.py
+++ b/src/g_nfl/utils/paths.py
@@ -1,19 +1,12 @@
-import os
 from pathlib import Path
 
-PROJECT_DIR = Path(os.getcwd().split("nfl-betting/")[0] + "nfl-betting/")
+PROJECT_DIR = Path(__file__).parents[3]
 
-BIN_PATH = PROJECT_DIR / "bin"
-LOGO_PATH = BIN_PATH / "logos"
+LOGO_PATH = PROJECT_DIR / "bin" / "logos"
 
 DATA_PATH = PROJECT_DIR / "data"
 
-BETTING_PATH = DATA_PATH / "betting"
-
 HOMERS_PATH = DATA_PATH / "homers"
-
-PFF_PROP_PATH = DATA_PATH / "pff-props"
-PFF_RATING_PATH = DATA_PATH / "pff-ratings"
 
 INPREDICABLE_PATH = DATA_PATH / "inpredictable"
 

--- a/src/g_nfl/utils/teams.py
+++ b/src/g_nfl/utils/teams.py
@@ -1,5 +1,3 @@
-import os
-
 import requests
 
 from g_nfl.utils.paths import LOGO_PATH
@@ -81,8 +79,7 @@ def download_team_pngs():
     base_url = "https://a.espncdn.com/i/teamlogos/nfl/500/"
 
     # Create the local directory if it doesn't exist
-    if not os.path.exists(LOGO_PATH):
-        os.makedirs(LOGO_PATH)
+    LOGO_PATH.mkdir(parents=True, exist_ok=True)
 
     # Iterate through the list of teams, download logos, and save them locally
     for team in nfl_teams:

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -1,0 +1,18 @@
+"""Tests for g_nfl.utils.paths (#51): PROJECT_DIR must resolve from
+__file__, not cwd."""
+
+import importlib
+
+from g_nfl.utils import paths
+
+
+def test_project_dir_is_repo_root():
+    assert (paths.PROJECT_DIR / "pyproject.toml").exists()
+
+
+def test_project_dir_independent_of_cwd(tmp_path, monkeypatch):
+    original = paths.PROJECT_DIR
+    monkeypatch.chdir(tmp_path)
+    reloaded = importlib.reload(paths)
+    assert reloaded.PROJECT_DIR == original
+    assert (reloaded.PROJECT_DIR / "pyproject.toml").exists()


### PR DESCRIPTION
Closes #51.

`PROJECT_DIR` was `Path(os.getcwd().split("nfl-betting/")[0] + "nfl-betting/")`. The split stopped matching when the repo was renamed `nfl-betting` -> `g-nfl`, so it appended to the whole cwd and produced `/Users/griffinreichert/code/g-nflnfl-betting`. Every derived constant was broken, and the result was cwd-dependent regardless.

Now `Path(__file__).parents[3]`, matching the pattern already in `ml/data.py`.

- Dropped constants with zero importers (`BIN_PATH`, `BETTING_PATH`, `PFF_PROP_PATH`, `PFF_RATING_PATH`); kept the ones `archive/scrapers.py`, `archive/homers.py`, `utils/logos.py` and `utils/connections.py` still import.
- Path hygiene at call sites: `/` operator over f-string concat, `Path.exists()`/`Path.mkdir()` over `os.path`.
- Removed `notebooks/picksnfl-betting/` — an untracked artifact of this exact bug.
- `tests/test_utils_paths.py` reloads the module under a changed cwd; confirmed failing pre-fix.

`bin/logos` had the assets all along — the broken path was hiding them. Team scatters render again.

**Noted, not fixed:** `utils/logos.py:38` reads `{team}.tif` while `utils/teams.py` and `archive/old_utils.py` download `{team}.png`, via a `download_team_pngs()` duplicated across both. Wants its own issue.

178 tests pass (176 baseline + 2 new). Lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JoYsDXJRAY8ZsPUCTKQrd