### PR TITLE
fix(utils): single logo fetch path, honest .png extension (#54)

### DIFF
--- a/src/g_nfl/archive/old_utils.py
+++ b/src/g_nfl/archive/old_utils.py
@@ -3,10 +3,7 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
-import requests
 from sklearn.linear_model import LinearRegression, Ridge
-
-from g_nfl.utils.paths import LOGO_PATH
 
 ############################
 #                          #
@@ -71,27 +68,6 @@ def standardize_teams(team):
     team = team_map.get(team, team)
     assert team in nfl_teams, print(team, "not in dict")
     return team
-
-
-def download_team_pngs():
-    # Base URL for the team logos and local directory
-    base_url = "https://a.espncdn.com/i/teamlogos/nfl/500/"
-
-    # Create the local directory if it doesn't exist
-    LOGO_PATH.mkdir(parents=True, exist_ok=True)
-
-    # Iterate through the list of teams, download logos, and save them locally
-    for team in nfl_teams:
-        team = team.lower()
-        url = f"{base_url}{team}.png"
-        response = requests.get(url)
-        if response.status_code == 200:
-            # Save the image to the local directory
-            with open(LOGO_PATH / f"{team}.png", "wb") as file:
-                file.write(response.content)
-        else:
-            print(f"Failed to download logo for {team}")
-    print(f"Logos downloaded to {LOGO_PATH}")
 
 
 ############################

--- a/src/g_nfl/utils/logos.py
+++ b/src/g_nfl/utils/logos.py
@@ -17,16 +17,22 @@ def get_logo_url(team: str, size: int = 25):
 
 
 def fetch_logos():
-    # if the path to the logos directory does not exist, create it
-    if not LOGO_PATH.exists():
-        print("fetching team logos...")
-        LOGO_PATH.mkdir(parents=True, exist_ok=True)
-        logos = nfl.load_teams().select(["team_abbr", "team_logo_espn"])
+    LOGO_PATH.mkdir(parents=True, exist_ok=True)
+    logos = nfl.load_teams().select(["team_abbr", "team_logo_espn"])
 
-        # get the logos for each team and store them to tif files in the logo path directory "<team>.tif"
-        for team, logo_url in logos.iter_rows():
-            urllib.request.urlretrieve(logo_url, LOGO_PATH / f"{team}.tif")
-        print("successfully retrieved logos")
+    # only fetch teams whose logo is missing so a partial/empty dir gets topped up
+    missing = [
+        (team, logo_url)
+        for team, logo_url in logos.iter_rows()
+        if not (LOGO_PATH / f"{team}.png").exists()
+    ]
+    if not missing:
+        return
+
+    print("fetching team logos...")
+    for team, logo_url in missing:
+        urllib.request.urlretrieve(logo_url, LOGO_PATH / f"{team}.png")
+    print("successfully retrieved logos")
 
 
 def get_team_logo(
@@ -34,6 +40,6 @@ def get_team_logo(
 ) -> OffsetImage:
     team = team.upper()
     # Open the image with PIL and resize it
-    image = Image.open(str(LOGO_PATH / f"{team}.tif"))
+    image = Image.open(str(LOGO_PATH / f"{team}.png"))
     image = image.resize(size, Image.Resampling.LANCZOS)
     return OffsetImage(np.asarray(image), alpha=alpha, zoom=1.0)

--- a/src/g_nfl/utils/teams.py
+++ b/src/g_nfl/utils/teams.py
@@ -1,7 +1,3 @@
-import requests
-
-from g_nfl.utils.paths import LOGO_PATH
-
 nfl_teams = {
     "ARI",
     "ATL",
@@ -72,24 +68,3 @@ def standardize_teams(team):
     team = team_map.get(team, team)
     assert team in nfl_teams, print(team, "not in dict")
     return team
-
-
-def download_team_pngs():
-    # Base URL for the team logos and local directory
-    base_url = "https://a.espncdn.com/i/teamlogos/nfl/500/"
-
-    # Create the local directory if it doesn't exist
-    LOGO_PATH.mkdir(parents=True, exist_ok=True)
-
-    # Iterate through the list of teams, download logos, and save them locally
-    for team in nfl_teams:
-        team = team.lower()
-        url = f"{base_url}{team}.png"
-        response = requests.get(url)
-        if response.status_code == 200:
-            # Save the image to the local directory
-            with open(LOGO_PATH / f"{team}.png", "wb") as file:
-                file.write(response.content)
-        else:
-            print(f"Failed to download logo for {team}")
-    print(f"Logos downloaded to {LOGO_PATH}")


### PR DESCRIPTION
Closes #54. Stacked on #52 (now merged), rebased onto `dev`.

Two parallel logo systems existed; one was dead.

- **Deleted** `download_team_pngs()` — duplicated verbatim in `utils/teams.py` and `archive/old_utils.py`, wrote lowercase `.png` files nothing ever read. Only surviving reference anywhere is a commented-out call in an archived notebook.
- **Honest extension:** ESPN serves PNG bytes; `fetch_logos()` was writing them as `.tif` and only worked because PIL sniffs content rather than trusting the suffix. Now `.png` on both write and read.
- **Fixed a latent staleness bug:** `fetch_logos()` guarded on `if not LOGO_PATH.exists()`, so a partial or empty directory never refetched. Now per-team, and silent when there is nothing to do.

Net −43 lines across 3 files.

Verified: cold start refetches, second run is a silent no-op, team scatters render. 178 tests pass, lint and format clean.

**Note, not a regression:** `fetch_logos()` writes 36 files, not 32 — `nflreadpy.load_teams()` returns relocated franchises (`OAK`/`LV`, `SD`/`LAC`, `STL`/`LA`) and never filters against `nfl_teams`. The old `.tif` set had the same 36. Harmless; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JoYsDXJRAY8ZsPUCTKQrd