### PR TITLE
feat(fantasy): rank delta against the room (#94)

### DIFF
--- a/app/pages/draft_board.py
+++ b/app/pages/draft_board.py
@@ -21,6 +21,7 @@ from g_nfl.fantasy.draft_board import (
     DEFAULT_TIER_GAP,
     attach_next_turn_value,
     attach_tiers,
+    attach_vs_ecr,
     load_ecr,
     picks_until_next_turn,
     snake_picks,
@@ -128,6 +129,7 @@ ecr, scrape_date = _ecr()
 
 board = build_board(score(stat_lines, config), config.teams, config.roster_positions)
 board = attach_tiers(board.join(ecr, on="gsis_id", how="left"), tier_gap)
+board = attach_vs_ecr(board)
 board = board.sort("overall_rank").select(["gsis_id", *BOARD_COLUMNS])
 
 picks_between = picks_until_next_turn(slot, teams, current_round)
@@ -202,6 +204,13 @@ st.dataframe(
         ),
         "ecr": st.column_config.NumberColumn("ECR", format="%.1f"),
         "sd": st.column_config.NumberColumn("ECR sd", format="%.1f"),
+        "vs_ecr": st.column_config.NumberColumn(
+            "vs ECR",
+            format="%+.0f",
+            help="ECR minus our rank. Positive = this league likes him more than "
+            "the room does. A very large delta is usually a projection problem, "
+            "not an edge.",
+        ),
         "floor": st.column_config.NumberColumn(
             "Floor",
             format="%.1f",

--- a/src/g_nfl/fantasy/draft_board.py
+++ b/src/g_nfl/fantasy/draft_board.py
@@ -35,6 +35,7 @@ BOARD_COLUMNS = [
     "ppgar",
     "ecr",
     "sd",
+    "vs_ecr",
 ]
 
 # A tier break is a ppgar drop bigger than this, in points per game. #78 settles
@@ -87,6 +88,19 @@ def attach_tiers(board: pl.DataFrame, gap: float = DEFAULT_TIER_GAP) -> pl.DataF
         .add(1)
         .alias("tier")
     )
+
+
+def attach_vs_ecr(board: pl.DataFrame) -> pl.DataFrame:
+    """``ecr - overall_rank``: who this league's scoring likes more than the room.
+
+    Positive means we rank the player higher than the consensus does, so he is
+    someone to wait on rather than reach for. Units are ranks over two different
+    populations — ECR is expert opinion under generic PPR, ``overall_rank`` is
+    PPGAR under *your* scoring — so part of every delta is the league config
+    doing its job. A very large one usually means a projection problem rather
+    than an edge, which makes this the column that tells you where to look.
+    """
+    return board.with_columns((pl.col("ecr") - pl.col("overall_rank")).alias("vs_ecr"))
 
 
 def snake_picks(slot: int, teams: int, rounds: int) -> list[int]:
@@ -169,6 +183,7 @@ def build_draft_board(
 
     ecr, scrape_date = load_ecr()
     board = attach_tiers(board.join(ecr, on="gsis_id", how="left"), tier_gap)
+    board = attach_vs_ecr(board)
     # gsis_id rides along: it is the join key for #86's outcome percentiles, and
     # ``to_markdown`` picks its own columns so it never reaches the table.
     board = board.sort("overall_rank").select(["gsis_id", *BOARD_COLUMNS])

--- a/src/g_nfl/fantasy/projections/board.py
+++ b/src/g_nfl/fantasy/projections/board.py
@@ -140,7 +140,7 @@ def to_markdown(board: pl.DataFrame, top: int = 60) -> str:
     cols += ["proj_ppg", "ppgar"]
     cols += [
         c
-        for c in ("ecr", "sd", "floor", "ceiling", "tprr", "yprr", "fdrr")
+        for c in ("ecr", "sd", "vs_ecr", "floor", "ceiling", "tprr", "yprr", "fdrr")
         if c in board.columns
     ]
     rows = board.head(top).select(cols).iter_rows()

--- a/tests/test_fantasy_draft_board.py
+++ b/tests/test_fantasy_draft_board.py
@@ -5,6 +5,7 @@ import polars as pl
 from g_nfl.fantasy.draft_board import (
     attach_next_turn_value,
     attach_tiers,
+    attach_vs_ecr,
     next_turn_outlook,
     picks_until_next_turn,
     snake_picks,
@@ -141,3 +142,18 @@ def test_vs_next_turn_is_value_over_the_real_alternative():
     assert rows["C"] == 0.0
     # Waiting past your next turn is negative value.
     assert rows["E"] == -4.0
+
+
+def test_vs_ecr_is_positive_when_we_like_a_player_more_than_the_room():
+    board = pl.DataFrame(
+        {
+            "overall_rank": [1, 2, 3],
+            "ecr": [10.0, 2.0, None],
+            "player_name": ["sleeper", "consensus", "unranked"],
+        }
+    )
+    deltas = attach_vs_ecr(board)["vs_ecr"].to_list()
+
+    assert deltas[0] == 9.0  # we rank him 1st, the room 10th
+    assert deltas[1] == 0.0
+    assert deltas[2] is None  # no consensus, no delta to report


### PR DESCRIPTION
Closes the free half of #94. The Vegas half stays out: it needs a sportsbook client this repo does not have, and #85 already ruled season props out of v1.

`vs_ecr` is `ecr - overall_rank`. Positive means this league's scoring likes a player more than the consensus does, so sorting by it gives the list to wait on and the list you are reaching for.

## It earns its keep as a sanity check immediately

The top six positive deltas inside the top 120 are five tight ends:

| Player | Our rank | ECR | vs ECR |
|---|---|---|---|
| Kenyon Sadiq | 96 | 218.3 | **+122** |
| T.J. Hockenson | 100 | 191.2 | +91 |
| Hunter Henry | 112 | 166.3 | +54 |
| Dallas Goedert | 70 | 122.3 | +52 |
| Mark Andrews | 81 | 127.5 | +47 |

That is not five sleepers. That is PPGAR measuring against a shallow one-TE replacement level while ECR ranks the same players against the whole draft. Part of every delta is the league config doing its job, which is said on the page so the number is not read as pure disagreement. A very large delta means "check this", not "draft this".

The negative side reads more like real disagreement: Mike Evans -43, Christian Watson -34, Brian Thomas Jr. -27 — players the room ranks well above where their ESPN projection lands.

## Verification

250 tests pass, one new covering the delta including the null case where FantasyPros does not rank a player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)