### PR TITLE
feat(fantasy): tier breaks are locally outsized drops (#78)

### DIFF
--- a/app/pages/draft_board.py
+++ b/app/pages/draft_board.py
@@ -18,7 +18,7 @@ import polars as pl
 
 from g_nfl.fantasy.draft_board import (
     BOARD_COLUMNS,
-    DEFAULT_TIER_GAP,
+    DEFAULT_TIER_SENSITIVITY,
     attach_next_turn_value,
     attach_tiers,
     attach_vs_ecr,
@@ -101,7 +101,15 @@ with st.sidebar.expander("Scoring"):
         fumble_lost=st.number_input("Fumble lost", -10.0, 0.0, p.fumble_lost, 1.0),
     )
 
-tier_gap = st.sidebar.slider("Tier gap (ppg)", 0.1, 3.0, DEFAULT_TIER_GAP, 0.05)
+tier_sensitivity = st.sidebar.slider(
+    "Tier sensitivity",
+    1.0,
+    4.0,
+    DEFAULT_TIER_SENSITIVITY,
+    0.05,
+    help="A tier break is a drop this many times the local median gap. "
+    "Lower means more, smaller tiers.",
+)
 
 show_outcomes = st.sidebar.checkbox(
     "Outcome range (slow)",
@@ -128,7 +136,7 @@ stat_lines = _stat_lines(SEASON)
 ecr, scrape_date = _ecr()
 
 board = build_board(score(stat_lines, config), config.teams, config.roster_positions)
-board = attach_tiers(board.join(ecr, on="gsis_id", how="left"), tier_gap)
+board = attach_tiers(board.join(ecr, on="gsis_id", how="left"), tier_sensitivity)
 board = attach_vs_ecr(board)
 board = board.sort("overall_rank").select(["gsis_id", *BOARD_COLUMNS])
 

--- a/src/g_nfl/fantasy/draft_board.py
+++ b/src/g_nfl/fantasy/draft_board.py
@@ -38,9 +38,16 @@ BOARD_COLUMNS = [
     "vs_ecr",
 ]
 
-# A tier break is a ppgar drop bigger than this, in points per game. #78 settles
-# the principled answer; this is a knob with a defensible default until then.
-DEFAULT_TIER_GAP = 0.75
+# A tier break is a drop this many times bigger than the drops around it (#78).
+# Relative, because ppgar gaps shrink by an order of magnitude down a position's
+# curve: one absolute threshold cannot serve both the top and the twentieth
+# player. 1.75 measured best over the top 40 — every position lands on tiers of
+# at most 8, which is the size that answers "wait or reach".
+DEFAULT_TIER_SENSITIVITY = 1.75
+
+# Gaps pooled to judge what "the drops around it" means. Nine is wide enough to
+# be stable and narrow enough to track the curve as it flattens.
+TIER_WINDOW = 9
 
 
 def load_ecr() -> tuple[pl.DataFrame, str]:
@@ -76,17 +83,52 @@ def load_ecr() -> tuple[pl.DataFrame, str]:
     return ecr, str(scrape_date)
 
 
-def attach_tiers(board: pl.DataFrame, gap: float = DEFAULT_TIER_GAP) -> pl.DataFrame:
-    """Number tiers per position: a new tier starts where ppgar drops by > ``gap``."""
-    return board.sort("ppgar", descending=True).with_columns(
-        (
-            (pl.col("ppgar").shift(1).over("position") - pl.col("ppgar")).fill_null(0.0)
-            > gap
+def attach_tiers(
+    board: pl.DataFrame,
+    sensitivity: float = DEFAULT_TIER_SENSITIVITY,
+    window: int = TIER_WINDOW,
+) -> pl.DataFrame:
+    """Number tiers per position. A break is a drop that stands out locally.
+
+    A cliff is only a cliff relative to the ground around it. Each gap between
+    consecutive players is compared against the median gap among its ``window``
+    neighbours, and a new tier starts where it is ``sensitivity`` times larger.
+
+    Two rejected alternatives, both measured on the live board (see
+    ``notes/fantasy-draft-board.md``):
+
+    - **A fixed ppg threshold**, which is what this replaces. Gaps shrink by an
+      order of magnitude down a position, so one number cannot fit the whole
+      curve: 0.75 ppg put 74 of the top-200 WRs in a single tier.
+    - **Distribution overlap** from #86, which sounds like the principled answer
+      and is not. Adjacent players' outcome ranges overlap so heavily that
+      ``P(next player scores more)`` sits between 0.34 and 0.59 across the
+      entire top 14 at RB and WR. No threshold separates anything, because
+      tiers are about cliffs in expected value, not statistical separation.
+
+    Tiers are per position, since that is how drafters think about waiting, and
+    they recompute over whatever board they are handed — so striking drafted
+    players (#79) re-tiers the survivors for free.
+    """
+    ranked = board.sort("ppgar", descending=True)
+    gap = (pl.col("ppgar").shift(1) - pl.col("ppgar")).over("position")
+    return (
+        ranked.with_columns(gap.alias("_gap"))
+        .with_columns(
+            (
+                pl.col("_gap")
+                > sensitivity
+                * pl.col("_gap")
+                .rolling_median(window, center=True, min_samples=3)
+                .over("position")
+            )
+            .fill_null(False)  # noqa: FBT003 — the first player starts a tier, not a break
+            .cum_sum()
+            .over("position")
+            .add(1)
+            .alias("tier")
         )
-        .cum_sum()
-        .over("position")
-        .add(1)
-        .alias("tier")
+        .drop("_gap")
     )
 
 
@@ -171,7 +213,9 @@ def attach_next_turn_value(
 
 
 def build_draft_board(
-    config: LeagueConfig, season: int, tier_gap: float = DEFAULT_TIER_GAP
+    config: LeagueConfig,
+    season: int,
+    tier_sensitivity: float = DEFAULT_TIER_SENSITIVITY,
 ) -> tuple[pl.DataFrame, dict[str, str]]:
     """Full pipeline. Returns the board and the provenance to print alongside it."""
     stat_lines = fetch_espn_projections(season)
@@ -182,7 +226,7 @@ def build_draft_board(
     )
 
     ecr, scrape_date = load_ecr()
-    board = attach_tiers(board.join(ecr, on="gsis_id", how="left"), tier_gap)
+    board = attach_tiers(board.join(ecr, on="gsis_id", how="left"), tier_sensitivity)
     board = attach_vs_ecr(board)
     # gsis_id rides along: it is the join key for #86's outcome percentiles, and
     # ``to_markdown`` picks its own columns so it never reaches the table.
@@ -225,7 +269,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--preset", default="ppr_12", choices=sorted(PRESETS))
     parser.add_argument("--season", type=int, default=2026)
-    parser.add_argument("--tier-gap", type=float, default=DEFAULT_TIER_GAP)
+    parser.add_argument(
+        "--tier-sensitivity",
+        type=float,
+        default=DEFAULT_TIER_SENSITIVITY,
+        help="a tier break is a drop this many times the local median gap",
+    )
     parser.add_argument("--top", type=int, default=100, help="rows in the markdown")
     parser.add_argument("--out-dir", type=Path, default=Path("data/fantasy"))
     parser.add_argument("--slot", type=int, help="your draft slot, 1-indexed")
@@ -239,7 +288,7 @@ def main() -> None:
     args = parser.parse_args()
 
     config = PRESETS[args.preset]
-    board, provenance = build_draft_board(config, args.season, args.tier_gap)
+    board, provenance = build_draft_board(config, args.season, args.tier_sensitivity)
 
     if args.outcomes:
         history_seasons = list(range(args.history[0], args.history[1] + 1))

--- a/tests/test_fantasy_draft_board.py
+++ b/tests/test_fantasy_draft_board.py
@@ -76,21 +76,53 @@ def test_reception_value_moves_receivers_relative_to_backs():
     assert wr_share_of_top(half) < wr_share_of_top(full)
 
 
-def test_tiers_break_on_gaps_and_number_per_position():
-    board = pl.DataFrame(
+def test_tiers_break_where_a_drop_stands_out_from_its_neighbours():
+    """Even gaps make one tier; a gap far bigger than its neighbours breaks it."""
+    even = pl.DataFrame(
         {
-            "position": ["WR", "WR", "WR", "RB", "RB"],
-            "ppgar": [10.0, 9.8, 5.0, 8.0, 7.9],
+            "position": ["WR"] * 8,
+            "ppgar": [10.0, 9.5, 9.0, 8.5, 8.0, 7.5, 7.0, 6.5],
         }
     )
-    tiered = attach_tiers(board, gap=1.0)
+    assert attach_tiers(even)["tier"].unique().to_list() == [1]
 
-    wr = tiered.filter(pl.col("position") == "WR").sort("ppgar", descending=True)
-    assert wr["tier"].to_list() == [1, 1, 2]
+    cliff = pl.DataFrame(
+        {
+            "position": ["WR"] * 8,
+            "ppgar": [10.0, 9.5, 9.0, 8.5, 5.0, 4.5, 4.0, 3.5],
+        }
+    )
+    tiers = attach_tiers(cliff).sort("ppgar", descending=True)["tier"].to_list()
+    assert tiers == [1, 1, 1, 1, 2, 2, 2, 2]
 
-    # Tiers restart per position, so the RBs are tier 1 despite lower ppgar.
-    rb = tiered.filter(pl.col("position") == "RB")
-    assert rb["tier"].to_list() == [1, 1]
+
+def test_tiers_are_relative_so_one_threshold_fits_both_ends_of_a_curve():
+    """The failure the fixed threshold had: a steep top and a flat tail.
+
+    The 4.0 drop at the top is ordinary for its neighbourhood, and the 0.4 drop
+    in the tail is a cliff for its own. An absolute gap sees only the first.
+    """
+    board = pl.DataFrame(
+        {
+            "position": ["RB"] * 10,
+            "ppgar": [30.0, 26.0, 22.0, 18.0, 14.0, 10.0, 9.6, 9.2, 8.8, 4.0],
+        }
+    )
+    tiers = attach_tiers(board).sort("ppgar", descending=True)["tier"].to_list()
+
+    assert tiers[:6] == [1] * 6  # the even 4.0 steps are one tier
+    assert tiers[-1] > tiers[-2]  # the tail cliff still breaks
+
+
+def test_tiers_restart_per_position():
+    board = pl.DataFrame(
+        {
+            "position": ["WR"] * 5 + ["RB"] * 5,
+            "ppgar": [10.0, 9.5, 9.0, 8.5, 8.0, 6.0, 5.5, 5.0, 4.5, 4.0],
+        }
+    )
+    tiered = attach_tiers(board)
+    assert tiered.filter(pl.col("position") == "RB")["tier"].to_list() == [1] * 5
 
 
 def test_snake_picks_reverse_on_even_rounds():


### PR DESCRIPTION
Closes #78. Retires the 0.75 ppg placeholder.

A tier break is now a drop **1.75x the median gap among its nine neighbours**, per position. Sensitivity is a slider on the page and `--tier-sensitivity` on the CLI.

## Why the fixed threshold could not work

ppgar gaps shrink by an order of magnitude down a position's curve, so no single number fits both ends. On the live board, 0.75 ppg gave:

| Position | Tiers over top 200 | Largest tier |
|---|---|---|
| WR | 5 | **74** |
| TE | 4 | 28 |
| QB | 4 | 23 |
| RB | 8 | 21 |

A tier spanning the whole middle of a position tells you nothing at the one moment it is meant to help. The relative rule holds the largest tier to 6 players over the top 60.

## Two alternatives measured and rejected

**Distribution overlap**, the option that sounded most principled, and now measurable thanks to #86. `P(next player outscores this one)` for adjacent pairs runs **0.34 to 0.59 across the entire top 14 at both RB and WR**. Every adjacent pair is a coin flip, so no threshold cuts anywhere. Outcome ranges are far wider than the gaps between neighbours — which means tiers mark cliffs in expected value, not statistical separation.

**Jenks / k-means** with the standard GVF ≥ 0.9 stopping rule. Variance is dominated by the top of each position, so it spends its clusters there and leaves WR a 26-player bottom tier. Fixing that needs a hand-set `k`, the arbitrary constant this ticket was retiring.

## Dependent choices, settled

- **Per position**, since that is how drafters think about waiting.
- **Tiers recompute over whatever board they are handed**, so #79's strike will re-tier the survivors with no extra work.

## Verification

252 tests pass. Three new: even gaps make one tier, an outsized gap breaks one, and the steep-top/flat-tail case the absolute threshold got wrong.

Full measurements and rejected parameter values in `notes/fantasy-draft-board.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)