### PR TITLE
feat(fantasy): rank on PPGAR, offer the alternatives as sorts (#77)

### DIFF
--- a/app/pages/draft_board.py
+++ b/app/pages/draft_board.py
@@ -19,12 +19,14 @@ import polars as pl
 from g_nfl.fantasy.draft_board import (
     BOARD_COLUMNS,
     DEFAULT_TIER_SENSITIVITY,
+    SORTS,
     attach_next_turn_value,
     attach_tiers,
     attach_vs_ecr,
     load_ecr,
     picks_until_next_turn,
     snake_picks,
+    sort_board,
 )
 from g_nfl.fantasy.outcomes import attach_outcomes, build_history, residuals
 from g_nfl.fantasy.projections.board import build_board
@@ -185,10 +187,22 @@ st.caption(
     "ADP replaces it in #92(c)."
 )
 
-positions = st.multiselect(
-    "Positions", ["QB", "RB", "WR", "TE"], default=["QB", "RB", "WR", "TE"]
-)
-shown = board.filter(board["position"].is_in(positions))
+left, right = st.columns([2, 1])
+with left:
+    positions = st.multiselect(
+        "Positions", ["QB", "RB", "WR", "TE"], default=["QB", "RB", "WR", "TE"]
+    )
+with right:
+    available = [s for s in SORTS if s in board.columns]
+    sort_by = st.selectbox(
+        "Rank by",
+        available,
+        format_func=lambda s: SORTS[s],
+        help="The # column stays PPGAR rank whatever you sort by, so it reads as "
+        "a fixed reference. Early rounds are where the floor is worth paying for; "
+        "by the last few, a bust gets dropped and the ceiling is nearly free.",
+    )
+shown = sort_board(board.filter(board["position"].is_in(positions)), sort_by)
 
 st.dataframe(
     shown.to_pandas(),

--- a/src/g_nfl/fantasy/draft_board.py
+++ b/src/g_nfl/fantasy/draft_board.py
@@ -132,6 +132,43 @@ def attach_tiers(
     )
 
 
+# What the board can be sorted by, and which direction is "better" (#77).
+# PPGAR is the default and the only cross-positionally comparable one: it is
+# measured against each position's own replacement level, so a point of RB PPGAR
+# and a point of WR PPGAR buy the same thing.
+#
+# P(top-N at position) was measured and rejected as the default. It correlates
+# 0.94 with PPGAR anyway, and where it disagrees it is usually wrong for a
+# structural reason: the threshold is per position (top 12 QB against top 36 WR),
+# so deep positions clear it more easily and drift up the board. It also
+# saturates near 0.5 through the middle rounds, exactly where a board is asked to
+# discriminate.
+#
+# Floor and ceiling stay as sorts because the round-dependent argument holds: an
+# early bust cannot be replaced so you pay for the floor, a late bust gets
+# dropped so the ceiling is close to free. One ranking statistic cannot say both,
+# and a sort selector is the cheap way to let the drafter say which one they are
+# buying this round.
+SORTS: dict[str, str] = {
+    "ppgar": "Value over replacement (default)",
+    "vs_next_turn": "Value over your next turn",
+    "floor": "Floor (10th percentile)",
+    "ceiling": "Ceiling (90th percentile)",
+    "vs_ecr": "Disagreement with the room",
+}
+
+
+def sort_board(board: pl.DataFrame, by: str = "ppgar") -> pl.DataFrame:
+    """Order the board by one of ``SORTS``, best first.
+
+    ``overall_rank`` keeps its PPGAR meaning whatever the sort, so the column
+    stays a stable reference rather than renumbering under the reader.
+    """
+    if by not in board.columns:
+        return board.sort("overall_rank")
+    return board.sort(by, descending=True, nulls_last=True)
+
+
 def attach_vs_ecr(board: pl.DataFrame) -> pl.DataFrame:
     """``ecr - overall_rank``: who this league's scoring likes more than the room.
 
@@ -277,6 +314,7 @@ def main() -> None:
     )
     parser.add_argument("--top", type=int, default=100, help="rows in the markdown")
     parser.add_argument("--out-dir", type=Path, default=Path("data/fantasy"))
+    parser.add_argument("--sort", default="ppgar", choices=sorted(SORTS))
     parser.add_argument("--slot", type=int, help="your draft slot, 1-indexed")
     parser.add_argument("--round", type=int, default=1, help="round you are picking in")
     parser.add_argument(
@@ -294,6 +332,8 @@ def main() -> None:
         history_seasons = list(range(args.history[0], args.history[1] + 1))
         resid = residuals(build_history(history_seasons, config))
         board = attach_outcomes(board, resid, args.season)
+
+    board = sort_board(board, args.sort)
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     stem = f"board_{args.season}_{args.preset}"

--- a/tests/test_fantasy_draft_board.py
+++ b/tests/test_fantasy_draft_board.py
@@ -9,6 +9,7 @@ from g_nfl.fantasy.draft_board import (
     next_turn_outlook,
     picks_until_next_turn,
     snake_picks,
+    sort_board,
 )
 from g_nfl.fantasy.projections.board import build_board
 from g_nfl.fantasy.scoring import HALF_PPR_12, PPR_12, score
@@ -189,3 +190,24 @@ def test_vs_ecr_is_positive_when_we_like_a_player_more_than_the_room():
     assert deltas[0] == 9.0  # we rank him 1st, the room 10th
     assert deltas[1] == 0.0
     assert deltas[2] is None  # no consensus, no delta to report
+
+
+def test_sort_board_reorders_without_renumbering():
+    board = pl.DataFrame(
+        {
+            "overall_rank": [1, 2, 3],
+            "ppgar": [9.0, 8.0, 7.0],
+            "ceiling": [12.0, 20.0, 15.0],
+        }
+    )
+    by_ceiling = sort_board(board, "ceiling")
+
+    assert by_ceiling["ceiling"].to_list() == [20.0, 15.0, 12.0]
+    # The rank column keeps its PPGAR meaning, so it reads as a fixed reference.
+    assert by_ceiling["overall_rank"].to_list() == [2, 3, 1]
+
+
+def test_sort_board_falls_back_when_the_column_is_absent():
+    """Floor and ceiling only exist when #86's opt-in outcomes are attached."""
+    board = pl.DataFrame({"overall_rank": [2, 1], "ppgar": [8.0, 9.0]})
+    assert sort_board(board, "floor")["overall_rank"].to_list() == [1, 2]


### PR DESCRIPTION
Closes #77. Names the ranking statistic, says what floor and ceiling show, and answers the "does the board expose more than one sort" question with yes.

## The ranking statistic is PPGAR

It is the only candidate comparable across positions: measured against each position's own replacement level, so a point of RB value and a point of WR value buy the same thing. `overall_rank` keeps that meaning under every sort, so the column reads as a fixed reference instead of renumbering under the reader.

## P(top-N at position), measured and rejected

Simulated from #86's distributions over the top 150, N set to leaguewide starters (12 QB, 24 RB, 36 WR, 12 TE):

- **Spearman 0.94 against PPGAR rank.** It mostly agrees, so it buys little.
- **Where it disagrees it is usually wrong, for a structural reason.** The threshold is per position, so deep positions clear it more easily. The eight biggest risers were six WRs and two QBs, every one with *negative* PPGAR — Jordan Addison rises 43 places at -1.06 ppgar. "Top 36 of a deep position" is an easier bar than "top 12 of a shallow one" and the statistic cannot see that.
- **It saturates near 0.5 through the middle rounds**, which is exactly where a board is asked to discriminate.

## Floor and ceiling are sorts, not the ranking

They genuinely reorder (0.77 and 0.64 against PPGAR rank), and the round-dependent argument in the ticket holds: an early bust cannot be replaced so you pay for the floor; a late bust gets dropped so the ceiling is nearly free. One ranking statistic cannot express both, and a sort selector lets the drafter say which one they are buying this round.

Sorts shipped: PPGAR (default), value over next turn (#92), floor, ceiling (#86, opt-in), disagreement with the room (#94). Floor and ceiling are p10 and p90 of the total outcome, luck included.

## Verification

254 tests pass, two new: sorting reorders without renumbering, and an absent column (floor before #86's opt-in runs) falls back to PPGAR rather than raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)