### PR TITLE
feat(fantasy): strike drafted players and revalue the board (#79)

### DIFF
--- a/app/pages/draft_board.py
+++ b/app/pages/draft_board.py
@@ -28,6 +28,7 @@ from g_nfl.fantasy.draft_board import (
     snake_picks,
     sort_board,
 )
+from g_nfl.fantasy.draft_state import load_drafted, save_drafted
 from g_nfl.fantasy.outcomes import attach_outcomes, build_history, residuals
 from g_nfl.fantasy.projections.board import build_board
 from g_nfl.fantasy.scoring import PRESETS, LeagueConfig, Scoring, score
@@ -118,6 +119,14 @@ show_outcomes = st.sidebar.checkbox(
     help="Floor and ceiling from historical role and luck residuals, 2019-2025 (#86).",
 )
 
+st.sidebar.markdown("### Draft state")
+st.sidebar.caption(
+    f"{len(load_drafted())} players struck. Saved to disk, so a refresh keeps them."
+)
+if st.sidebar.button("Clear draft", width="stretch"):
+    save_drafted(set())
+    st.rerun()
+
 st.sidebar.markdown("### Your turn")
 slot = st.sidebar.number_input("Draft slot", 1, teams, min(1, teams))
 rounds = len(roster_positions) + bench if roster_positions else 1
@@ -137,7 +146,14 @@ if not roster_positions:
 stat_lines = _stat_lines(SEASON)
 ecr, scrape_date = _ecr()
 
-board = build_board(score(stat_lines, config), config.teams, config.roster_positions)
+# Drafted players come out of the pool *before* build_board, so replacement
+# level is derived from who is actually left. That is the whole point of #79
+# option 2: positional scarcity is dynamic, and a board that ignores it keeps
+# telling you RBs are valuable long after the RB run has ended.
+drafted = load_drafted()
+available = stat_lines.filter(~pl.col("gsis_id").is_in(list(drafted)))
+
+board = build_board(score(available, config), config.teams, config.roster_positions)
 board = attach_tiers(board.join(ecr, on="gsis_id", how="left"), tier_sensitivity)
 board = attach_vs_ecr(board)
 board = board.sort("overall_rank").select(["gsis_id", *BOARD_COLUMNS])
@@ -152,7 +168,7 @@ if show_outcomes:
 
 board = board.with_columns(
     pl.col("team").map_elements(get_team_logo, return_dtype=pl.Utf8).alias("logo")
-).select(["logo", *BOARD_COLUMNS, "vs_next_turn", *outcome_columns])
+).select(["gsis_id", "logo", *BOARD_COLUMNS, "vs_next_turn", *outcome_columns])
 
 st.caption(
     f"**{label}** — {teams} teams, {'/'.join(roster_positions)}, {bench} bench. "
@@ -204,12 +220,17 @@ with right:
     )
 shown = sort_board(board.filter(board["position"].is_in(positions)), sort_by)
 
-st.dataframe(
-    shown.to_pandas(),
+edited = st.data_editor(
+    shown.with_columns(pl.lit(False).alias("drafted")).to_pandas(),
     width="stretch",
     hide_index=True,
     height=800,
+    disabled=[c for c in shown.columns if c != "drafted"],
     column_config={
+        "drafted": st.column_config.CheckboxColumn(
+            "Drafted", help="Tick to take the player off the board.", width="small"
+        ),
+        "gsis_id": None,
         "logo": st.column_config.ImageColumn("", width="small"),
         "overall_rank": st.column_config.NumberColumn("#", width="small"),
         "player_name": st.column_config.TextColumn("Player"),
@@ -249,6 +270,11 @@ st.dataframe(
         ),
     },
 )
+
+struck = set(edited.loc[edited["drafted"], "gsis_id"])
+if struck:
+    save_drafted(drafted | struck)
+    st.rerun()
 
 st.download_button(
     "⬇️ Download CSV",

--- a/src/g_nfl/fantasy/draft_state.py
+++ b/src/g_nfl/fantasy/draft_state.py
@@ -1,0 +1,37 @@
+"""Who has already been drafted, and where that fact survives (issue #79).
+
+A JSON file on disk, not session state and not a database. Three reasons, all
+about draft day:
+
+- **A refresh mid-draft must not lose 40 picks.** Streamlit's session state does
+  not survive one, so it cannot hold this.
+- **Wifi must not be able to break the board.** Supabase (#81) is the store for
+  everything the app *reads*; draft state is the one thing it writes, at the
+  worst possible moment for a network round trip.
+- The file is trivially inspectable and deletable when the draft is over.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+DEFAULT_PATH = Path("data/fantasy/draft_state.json")
+
+
+def load_drafted(path: Path = DEFAULT_PATH) -> set[str]:
+    """The ``gsis_id`` set already off the board. Missing file means none."""
+    if not path.exists():
+        return set()
+    return set(json.loads(path.read_text())["drafted"])
+
+
+def save_drafted(drafted: set[str], path: Path = DEFAULT_PATH) -> None:
+    """Persist the set, creating the directory on the way."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"drafted": sorted(drafted)}, indent=2))
+
+
+def toggle(drafted: set[str], gsis_id: str, *, is_drafted: bool) -> set[str]:
+    """Add or remove one player, returning a new set."""
+    return drafted | {gsis_id} if is_drafted else drafted - {gsis_id}

--- a/tests/test_fantasy_draft_state.py
+++ b/tests/test_fantasy_draft_state.py
@@ -1,0 +1,61 @@
+"""Draft state persistence and what striking does to the board (issue #79)."""
+
+import polars as pl
+
+from g_nfl.fantasy.draft_state import load_drafted, save_drafted, toggle
+from g_nfl.fantasy.projections.board import build_board
+
+
+def test_state_survives_a_round_trip(tmp_path):
+    """A refresh mid-draft must not lose picks, so this cannot live in memory."""
+    path = tmp_path / "nested" / "draft_state.json"
+    save_drafted({"00-0001", "00-0002"}, path)
+
+    assert load_drafted(path) == {"00-0001", "00-0002"}
+
+
+def test_missing_file_is_an_empty_draft(tmp_path):
+    assert load_drafted(tmp_path / "absent.json") == set()
+
+
+def test_toggle_adds_and_removes():
+    assert toggle(set(), "a", is_drafted=True) == {"a"}
+    assert toggle({"a", "b"}, "a", is_drafted=False) == {"b"}
+
+
+def _pool() -> pl.DataFrame:
+    """Twelve RBs and twelve WRs on a declining curve."""
+    return pl.DataFrame(
+        {
+            "gsis_id": [f"rb{i}" for i in range(12)] + [f"wr{i}" for i in range(12)],
+            "player_name": [f"RB {i}" for i in range(12)]
+            + [f"WR {i}" for i in range(12)],
+            "position": ["RB"] * 12 + ["WR"] * 12,
+            "proj_ppg": [20.0 - i for i in range(12)] + [20.0 - i for i in range(12)],
+        }
+    )
+
+
+def test_striking_a_run_of_backs_revalues_the_rest():
+    """The reason strike recomputes rather than greying rows out.
+
+    Take the top six RBs off the board and replacement level at RB drops to a
+    worse player, so every surviving back gains against it. A board that ignored
+    this would keep pricing RBs off a pool that no longer exists.
+
+    Receivers gain too, and that is not a bug: with the backs gone the FLEX slot
+    starts eating WRs, which pushes WR replacement deeper. Positional scarcity
+    is coupled through the flex, which is precisely what a static board cannot
+    show you.
+    """
+    roster = ["RB", "RB", "WR", "WR", "FLEX"]
+    full = build_board(_pool(), teams=2, roster_positions=roster)
+
+    survivors = _pool().filter(~pl.col("gsis_id").is_in([f"rb{i}" for i in range(6)]))
+    after = build_board(survivors, teams=2, roster_positions=roster)
+
+    def ppgar(board: pl.DataFrame, gsis_id: str) -> float:
+        return board.filter(pl.col("gsis_id") == gsis_id)["ppgar"][0]
+
+    assert ppgar(after, "rb6") > ppgar(full, "rb6")
+    assert ppgar(after, "wr0") > ppgar(full, "wr0")


### PR DESCRIPTION
Closes #79.

## The option chosen: 2, recompute replacement level

Drafted players leave the pool **before** `build_board` runs, so replacement level is derived from who is actually left. Verified on the live board: strike the top two and Bijan Robinson moves 9.49 → 9.62 ppgar with no change to his projection.

Strike-through only (option 1) would have left the board telling you RBs are valuable long after the RB run has ended. Roster-aware weighting (option 3) is **ruled out for v1** — that is a different tool, and it is not what a board is.

## Where the recompute runs: in the Streamlit process

The map puts compute in a FastAPI endpoint, which is right for #82 after the draft. Before it, a per-pick network round trip on draft-day wifi is a risk with nothing to buy it.

## Does state persist: yes, in a file

`data/fantasy/draft_state.json`. Session state loses everything on a refresh, which mid-draft is a real failure mode. Supabase (#81) is the store for what the app *reads*; draft state is the one thing it writes, at the worst possible moment for a round trip. A file survives both and is trivially inspectable and deletable.

## How state gets in

A checkbox column in the table, plus a "Clear draft" button in the sidebar. Live Sleeper draft import stays out of v1.

## One finding worth keeping

Striking a run of backs raises **receivers** too: with the RBs gone the FLEX slot starts eating WRs, pushing WR replacement deeper. Positional scarcity is coupled through the flex, and a static board cannot show that at all. Asserted in the tests rather than left as a surprise.

## Verification

258 tests pass, 4 new (round trip, missing file, toggle, and the revaluation above). Strike path checked end to end through `AppTest`: 500 rows → 498, struck players gone, survivors repriced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)