### PR TITLE
feat(fantasy): survival from ADP, not board order (#99)

### DIFF
--- a/app/pages/draft_board.py
+++ b/app/pages/draft_board.py
@@ -29,10 +29,16 @@ from g_nfl.fantasy.draft_board import (
     sort_board,
 )
 from g_nfl.fantasy.draft_state import load_drafted, save_drafted
-from g_nfl.fantasy.outcomes import attach_outcomes, build_history, residuals
+from g_nfl.fantasy.outcomes import (
+    attach_outcomes,
+    build_history,
+    load_adp,
+    residuals,
+)
 from g_nfl.fantasy.projections.board import build_board
 from g_nfl.fantasy.scoring import PRESETS, LeagueConfig, Scoring, score
 from g_nfl.fantasy.sources.espn import fetch_espn_projections
+from g_nfl.fantasy.survival import consensus_pick, survival
 from g_nfl.utils.web_app import get_team_logo
 
 SEASON = 2026
@@ -50,6 +56,11 @@ def _stat_lines(season: int):
 @st.cache_data(show_spinner="Loading FantasyPros ECR...")
 def _ecr():
     return load_ecr()
+
+
+@st.cache_data(show_spinner="Loading ADP...")
+def _adp(season: int):
+    return load_adp(season)
 
 
 # Keyed on the scoring config: role ratios are near scale-free, but luck is
@@ -159,7 +170,10 @@ board = attach_vs_ecr(board)
 board = board.sort("overall_rank").select(["gsis_id", *BOARD_COLUMNS])
 
 picks_between = picks_until_next_turn(slot, teams, current_round)
-board, outlook = attach_next_turn_value(board, picks_between)
+next_pick = snake_picks(slot, teams, current_round + 1)[current_round]
+board = consensus_pick(board, _adp(SEASON))
+board, outlook = attach_next_turn_value(board, picks_between, next_pick)
+board = survival(board, next_pick)
 
 outcome_columns: list[str] = []
 if show_outcomes:
@@ -168,7 +182,9 @@ if show_outcomes:
 
 board = board.with_columns(
     pl.col("team").map_elements(get_team_logo, return_dtype=pl.Utf8).alias("logo")
-).select(["gsis_id", "logo", *BOARD_COLUMNS, "vs_next_turn", *outcome_columns])
+).select(
+    ["gsis_id", "logo", *BOARD_COLUMNS, "vs_next_turn", "p_available", *outcome_columns]
+)
 
 st.caption(
     f"**{label}** — {teams} teams, {'/'.join(roster_positions)}, {bench} bench. "
@@ -198,9 +214,9 @@ st.dataframe(
     },
 )
 st.caption(
-    "Survival is a proxy: it assumes the next "
-    f"{picks_between} picks take the next {picks_between} players in board order. "
-    "ADP replaces it in #92(c)."
+    f"Survival is modelled from ADP: a player lasts to pick {next_pick} if his draft "
+    "position, normal around his ADP with the spread from min/max pick, falls after "
+    "it. QBs use ECR instead, since MFL pools superflex rooms into one ADP feed."
 )
 
 left, right = st.columns([2, 1])
@@ -261,6 +277,13 @@ edited = st.data_editor(
         ),
         "ceiling": st.column_config.NumberColumn(
             "Ceiling", format="%.1f", help="90th percentile ppg."
+        ),
+        "p_available": st.column_config.NumberColumn(
+            "Still there?",
+            format="percent",
+            help="Chance he lasts to your next pick, from ADP spread. "
+            "QBs use FantasyPros ECR instead: MFL pools superflex rooms into one "
+            "ADP feed, which takes quarterbacks far too early for a 1QB league.",
         ),
         "vs_next_turn": st.column_config.NumberColumn(
             "vs next turn",

--- a/src/g_nfl/fantasy/draft_board.py
+++ b/src/g_nfl/fantasy/draft_board.py
@@ -19,10 +19,16 @@ from pathlib import Path
 import nflreadpy
 import polars as pl
 
-from g_nfl.fantasy.outcomes import attach_outcomes, build_history, residuals
+from g_nfl.fantasy.outcomes import (
+    attach_outcomes,
+    build_history,
+    load_adp,
+    residuals,
+)
 from g_nfl.fantasy.projections.board import build_board, to_markdown
 from g_nfl.fantasy.scoring import PRESETS, LeagueConfig, score
 from g_nfl.fantasy.sources.espn import fetch_espn_projections
+from g_nfl.fantasy.survival import best_expected_available, consensus_pick
 
 BOARD_COLUMNS = [
     "overall_rank",
@@ -206,20 +212,26 @@ def _best_available(board: pl.DataFrame) -> pl.DataFrame:
     return board.sort("overall_rank").group_by("position", maintain_order=True).first()
 
 
-def next_turn_outlook(board: pl.DataFrame, picks_between: int) -> pl.DataFrame:
+def next_turn_outlook(
+    board: pl.DataFrame, picks_between: int, next_pick: int | None = None
+) -> pl.DataFrame:
     """What the top of each position looks like now, and at your next turn.
 
-    Survival model: the next ``picks_between`` picks take the next
-    ``picks_between`` players *in board order*. That is a proxy, and a
-    self-flattering one, since it assumes the room drafts off this board. #92(c)
-    replaces it with ADP, where ``minPick``/``maxPick`` give a real spread.
+    With ``next_pick`` and ADP on the board (#99), "still there" means more
+    likely than not to survive to that pick. Without them it falls back to board
+    order: the next ``picks_between`` picks take the next ``picks_between``
+    players on this board, which assumes the room drafts off it.
     """
     now = _best_available(board).select(
         "position",
         pl.col("player_name").alias("best_now"),
         pl.col("ppgar").alias("ppgar_now"),
     )
-    later = _best_available(board.sort("overall_rank").slice(picks_between)).select(
+    if next_pick is not None and "pick_mu" in board.columns:
+        survivors = best_expected_available(board, next_pick)
+    else:
+        survivors = _best_available(board.sort("overall_rank").slice(picks_between))
+    later = survivors.select(
         "position",
         pl.col("player_name").alias("best_next_turn"),
         pl.col("ppgar").alias("ppgar_next_turn"),
@@ -234,7 +246,7 @@ def next_turn_outlook(board: pl.DataFrame, picks_between: int) -> pl.DataFrame:
 
 
 def attach_next_turn_value(
-    board: pl.DataFrame, picks_between: int
+    board: pl.DataFrame, picks_between: int, next_pick: int | None = None
 ) -> tuple[pl.DataFrame, pl.DataFrame]:
     """Add ``vs_next_turn``: ppgar over the best of that position at your next turn.
 
@@ -242,7 +254,7 @@ def attach_next_turn_value(
     season. ``vs_next_turn`` measures him against the alternative you actually
     face, which is the one the draft asks about.
     """
-    outlook = next_turn_outlook(board, picks_between)
+    outlook = next_turn_outlook(board, picks_between, next_pick)
     scored = board.join(
         outlook.select("position", "ppgar_next_turn"), on="position", how="left"
     ).with_columns((pl.col("ppgar") - pl.col("ppgar_next_turn")).alias("vs_next_turn"))
@@ -351,11 +363,13 @@ def main() -> None:
     if args.slot:
         gap = picks_until_next_turn(args.slot, config.teams, args.round)
         picks = snake_picks(args.slot, config.teams, args.round + 1)
+        next_pick = picks[args.round]
+        board = consensus_pick(board, load_adp(args.season))
         print(
             f"\nSlot {args.slot}, round {args.round}: pick {picks[args.round - 1]}, "
-            f"then pick {picks[args.round]} — {gap} picks in between."
+            f"then pick {next_pick} — {gap} picks in between."
         )
-        print(next_turn_outlook(board, gap))
+        print(next_turn_outlook(board, gap, next_pick))
 
     print(f"\nWrote {csv_path} and {md_path}")
 

--- a/src/g_nfl/fantasy/survival.py
+++ b/src/g_nfl/fantasy/survival.py
@@ -1,0 +1,99 @@
+"""Will he last until your next pick? (issue #99, split from #92c)
+
+Replaces the board-order proxy in ``next_turn_outlook``. That proxy assumed the
+next N picks take the next N players *on this board*, which assumes the room
+drafts off this board — flattering, and wrong in exactly the place it matters,
+since the players this board likes more than the market are the ones it claims
+will not survive.
+
+The model is deliberately plain: a player's draft position is normal around his
+ADP, with the spread read off ``minPick``/``maxPick``, and survival is the tail
+above your next pick. Resist making it fancy before it is useful.
+
+**QB carries a measured caveat.** MyFantasyLeague pools superflex rooms into one
+ADP feed and ignores every filter parameter tried (``IS_SF``, ``IS_SUPERFLEX``),
+so quarterbacks come back far too early for a 1QB league: Josh Allen's 2026 ADP
+is 2.8 against an ECR of 25.9. For QBs the consensus pick therefore comes from
+FantasyPros ECR, which is published 1QB PPR and ships its own ``sd``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import polars as pl
+
+# Range of a normal covering roughly four standard deviations, used to turn
+# MFL's min/max picks into a spread.
+RANGE_TO_SD = 4.0
+
+# No player is a certainty, and a zero spread would make survival a step
+# function at his ADP.
+MIN_PICK_SD = 1.5
+
+# A player is "expected to be there" above this survival probability. Half is
+# the honest reading of a coin-flip threshold: better than not.
+SURVIVAL_THRESHOLD = 0.5
+
+
+def consensus_pick(board: pl.DataFrame, adp: pl.DataFrame) -> pl.DataFrame:
+    """Attach ``pick_mu`` and ``pick_sd``: where the room takes a player.
+
+    ADP for skill positions, ECR for quarterbacks (see the module docstring for
+    why). Players in neither source get no estimate and fall back to board order
+    downstream.
+    """
+    joined = board.join(
+        adp.select("gsis_id", "adp", "adp_min", "adp_max"), on="gsis_id", how="left"
+    )
+    is_qb = pl.col("position") == "QB"
+    return joined.with_columns(
+        pl.when(is_qb).then(pl.col("ecr")).otherwise(pl.col("adp")).alias("pick_mu"),
+        pl.when(is_qb)
+        .then(pl.col("sd"))
+        .otherwise((pl.col("adp_max") - pl.col("adp_min")) / RANGE_TO_SD)
+        .clip(lower_bound=MIN_PICK_SD)
+        .alias("pick_sd"),
+    ).drop("adp", "adp_min", "adp_max")
+
+
+def survival(board: pl.DataFrame, pick: int) -> pl.DataFrame:
+    """Attach ``p_available``: the chance a player is still there at ``pick``.
+
+    ``1 - Phi((pick - mu) / sd)``, so a player whose ADP sits well before your
+    pick is unlikely to last and one whose ADP is well after it almost certainly
+    will. Players with no consensus estimate get a null, not a guess.
+    """
+    z = (pl.lit(float(pick)) - pl.col("pick_mu")) / pl.col("pick_sd")
+    normal_cdf = 0.5 * (
+        1 + (z / math.sqrt(2)).map_batches(_erf, return_dtype=pl.Float64)
+    )
+    return board.with_columns(
+        pl.when(pl.col("pick_mu").is_null())
+        .then(None)
+        .otherwise((1 - normal_cdf).clip(0.0, 1.0))
+        .alias("p_available")
+    )
+
+
+def _erf(s: pl.Series) -> pl.Series:
+    """``math.erf`` over a series; polars has no erf expression."""
+    return pl.Series([None if v is None else math.erf(v) for v in s], dtype=pl.Float64)
+
+
+def best_expected_available(
+    board: pl.DataFrame, pick: int, threshold: float = SURVIVAL_THRESHOLD
+) -> pl.DataFrame:
+    """Top player per position more likely than not to reach ``pick``.
+
+    Falls back to board order for anyone the sources do not cover, which is the
+    deep end of the board where the old proxy was least wrong anyway.
+    """
+    survivors = survival(board, pick).filter(
+        pl.col("p_available").is_null() | (pl.col("p_available") >= threshold)
+    )
+    return (
+        survivors.sort("ppgar", descending=True)
+        .group_by("position", maintain_order=True)
+        .first()
+    )

--- a/tests/test_fantasy_survival.py
+++ b/tests/test_fantasy_survival.py
@@ -1,0 +1,79 @@
+"""Will he last to your next pick? (issue #99). Network-free."""
+
+import polars as pl
+
+from g_nfl.fantasy.survival import (
+    MIN_PICK_SD,
+    best_expected_available,
+    consensus_pick,
+    survival,
+)
+
+
+def _board() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "gsis_id": ["early", "late", "qb", "unknown"],
+            "player_name": ["Early WR", "Late RB", "The QB", "Nobody"],
+            "position": ["WR", "RB", "QB", "WR"],
+            "ppgar": [9.0, 5.0, 4.0, 8.0],
+            "ecr": [4.0, 40.0, 26.0, None],
+            "sd": [1.0, 8.0, 3.0, None],
+        }
+    )
+
+
+def _adp() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "gsis_id": ["early", "late", "qb"],
+            "adp": [4.0, 40.0, 3.0],
+            "adp_min": [1.0, 30.0, 1.0],
+            "adp_max": [9.0, 50.0, 11.0],
+        }
+    )
+
+
+def test_quarterbacks_use_ecr_because_the_adp_feed_pools_superflex():
+    """MFL takes QBs far too early for a 1QB league, so ECR stands in."""
+    picked = consensus_pick(_board(), _adp())
+    by_id = {r["gsis_id"]: r for r in picked.iter_rows(named=True)}
+
+    assert by_id["qb"]["pick_mu"] == 26.0  # ECR, not the ADP of 3.0
+    assert by_id["early"]["pick_mu"] == 4.0  # skill positions keep ADP
+    assert by_id["early"]["pick_sd"] == 2.0  # (9 - 1) / 4
+
+
+def test_a_zero_spread_still_leaves_room_for_doubt():
+    board = _board().head(1)
+    adp = pl.DataFrame(
+        {"gsis_id": ["early"], "adp": [4.0], "adp_min": [4.0], "adp_max": [4.0]}
+    )
+    assert consensus_pick(board, adp)["pick_sd"][0] == MIN_PICK_SD
+
+
+def test_survival_rises_with_the_pick_you_are_waiting_for():
+    picked = consensus_pick(_board(), _adp())
+    at_10 = survival(picked, 10)
+    at_60 = survival(picked, 60)
+
+    def p(frame: pl.DataFrame, gsis_id: str) -> float:
+        return frame.filter(pl.col("gsis_id") == gsis_id)["p_available"][0]
+
+    assert p(at_10, "early") < 0.01  # ADP 4, sd 2: long gone by pick 10
+    assert p(at_10, "late") > 0.99  # ADP 40: certain to be there
+    assert p(at_60, "late") < 0.05  # by pick 60 he is not
+
+    # No consensus estimate means no guess.
+    assert p(at_10, "unknown") is None
+
+
+def test_best_expected_available_skips_players_who_will_be_gone():
+    """The correction over board order: the best survivor, not the next name."""
+    picked = consensus_pick(_board(), _adp())
+    best = best_expected_available(picked, 20)
+    by_position = {r["position"]: r["player_name"] for r in best.iter_rows(named=True)}
+
+    assert by_position["RB"] == "Late RB"
+    # The uncovered player falls back rather than vanishing from the board.
+    assert by_position["WR"] == "Nobody"


### PR DESCRIPTION
Closes #99 (the #92(c) split).

The board-order proxy assumed the next N picks take the next N players **on this board**, which assumes the room drafts off it. Flattering, and wrong exactly where it matters: the players this board likes more than the market are the ones the proxy claimed would be gone.

A player's draft position is now normal around his ADP, spread read off `minPick`/`maxPick` (range/4, floored at 1.5), and survival is the tail above your next pick. "Best available at your next turn" is the top player per position more likely than not to reach it.

## The correction is large

Slot 4, round 1, next pick 21:

| Pos | Proxy said | ADP says | Cost of waiting |
|---|---|---|---|
| RB | Kenneth Walker III | Christian McCaffrey | 5.46 → **1.33** |
| TE | Trey McBride survives | Tyler Warren | 0.00 → **1.99** |
| WR | Rashee Rice | Rashee Rice | 5.11 → 5.11 |

McCaffrey's ADP is later than his board rank, so he is expected to survive and the RB reach evaporates. McBride's is earlier, so the free tight end the proxy promised was never free.

## A trap worth knowing about: MFL pools superflex

MyFantasyLeague's ADP feed mixes superflex rooms and **cannot be filtered** — `IS_SF=0` and `IS_SUPERFLEX=0` are both accepted and both ignored, returning byte-identical 684-player payloads. Josh Allen's 2026 ADP is **2.8 against an ECR of 25.9**.

So quarterbacks take their consensus pick from **FantasyPros ECR**, which is published 1QB PPR and ships its own `sd`. Everything else uses ADP. This is called out in the module docstring, the column help text and the page caption, since anyone reading a QB survival number needs to know which source produced it.

## Coverage

399 players: **100% of the board's top 150**, 73.6% overall. Players in neither source get a null rather than a guess and fall back to board order — the deep end, where the proxy was least wrong anyway.

## Verification

262 tests pass, 4 new: the QB substitution, the zero-spread floor, survival rising with the pick you wait for, and the fallback for uncovered players. Page checked through `AppTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)