### PR TITLE
chore: delete scratch/, findings triaged into notes (#95)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,12 @@ The `notes/` folder is the source of truth for in-flight, multi-session work. Us
 
 ### One-off analysis scripts — no `scratch/` folder
 
-There is no in-repo scratch/scratchpad directory (removed 2026-08-09 — it had
-become a dumping ground for sweep/backtest scripts whose findings never made it
-into `notes/`). Disposition for a throwaway script:
+There is no in-repo scratch/scratchpad directory. The rule was written
+2026-08-09; the 31 files it was written about were only triaged and deleted
+2026-08-17 (#95), and the findings that had never left those scripts are now in
+`notes/modelling/error-breakdowns.md`. `scratch/` is deliberately **not** in
+`.gitignore`, so if one reappears it shows up in `git status` instead of hiding.
+Disposition for a throwaway script:
 
 - **Write it to the session scratchpad** (outside the repo, e.g.
   `/private/tmp/claude-*/.../scratchpad`), not into a repo folder.


### PR DESCRIPTION
Closes #95.

31 untracked files, 2026-06-29 to 2026-07-08, all ML spread-model sweeps and holdout gates. They also held the only 3 ruff errors in the repo.

## Triage

**Bucket 1 — verdict already recorded, deleted as-is.** Moneyline (#29), key-numbers rerank, Massey power ratings, injuries, schedule, QB, O-line continuity, carryover k=8 and its holdout gate. All in `reports/BASELINES.md` or `notes/modelling/scoreboard.md`. The fantasy efficiency backtest's verdict lives in the `efficiency.py` module docstring.

**Bucket 2 — finding written up first.** The #45 error-breakdown chain was the real risk: the slice tables, the big-line calibration probe (`close ~ pred` slope 1.089), the walk-forward recalibration sweep, the disagreement cap, and the #49 wp-filter/min-week holdout FAIL existed only in the scripts plus issue comments. All now in `notes/modelling/error-breakdowns.md`, which had been sitting at "Status: not built" since 2026-07-07. Also un-stalled `key-numbers.md` and `model-architectures.md`, which still read as open work for levers that have since been shot.

**Bucket 3 — nothing.** The `holdout*_gate.py` scripts are the closest to a reusable tool, but they monkeypatch `evaluate.build_features` to fake a `wp_filter` passthrough that `backtest()` does not expose. Generalising them is an API change, so it belongs in its own ticket rather than in this cleanup.

## Verification

- `make lint` (`ruff check .`) passes clean with no path filtering, for the first time in a while.
- 262 tests pass.
- `scratch/` is deliberately still absent from `.gitignore`, so a new one shows up in `git status` rather than hiding.

## Note

`ruff format --check` still flags `src/g_nfl/picks/analytics.py` (one cosmetic paren). Pre-existing and unrelated; pre-commit will fix it on the next commit that touches the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)