### PR TITLE
feat(fantasy): fantasy_projections store and ingest CLI (#81)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev run api web deploy-prep clean lint format test jupyter streamlit train backtest market-ratings mlflow-ui update-context
+.PHONY: help install dev run api web deploy-prep clean lint format test jupyter streamlit train backtest market-ratings mlflow-ui update-context ingest-fantasy
 
 # Default target
 help:
@@ -21,6 +21,7 @@ help:
 	@echo "  verify-db     Verify database tables exist"
 	@echo "  load-pool     Load pool standings workbook (ARGS=\"<xlsx> --season 2025\")"
 	@echo "  pool-report   Pool pick-trend report (ARGS=\"<xlsx> --season 2025\")"
+	@echo "  ingest-fantasy Snapshot fantasy projections to Supabase (SEASON=2026)"
 	@echo ""
 	@echo "🤖 ML:"
 	@echo "  train         Train the spread model (ARGS=\"--seasons 2023 2024\")"
@@ -90,6 +91,14 @@ load-pool:
 pool-report:
 	@echo "📈 Pool pick-trend report..."
 	uv run python -m g_nfl.pool.analysis $(ARGS)
+
+# The season being drafted for. Not CUR_SEASON in config.py, which still reads
+# 2025 — see #81's PR.
+SEASON ?= 2026
+
+ingest-fantasy:
+	@echo "📥 Snapshotting fantasy projections to Supabase..."
+	uv run python -m g_nfl.fantasy.ingest --season $(SEASON) $(ARGS)
 
 verify-db-test:
 	@echo "🧪 Testing database operations..."

--- a/scripts/fantasy_projections_schema.sql
+++ b/scripts/fantasy_projections_schema.sql
@@ -1,0 +1,48 @@
+-- Season-total fantasy stat-line projections (issue #81).
+--
+-- Filled by `make ingest-fantasy` (g_nfl.fantasy.ingest), which Griffin runs
+-- by hand. The API never scrapes: a broken source leaves the last good
+-- snapshot serving, and there is no scrape in the request path to blow a
+-- Render cold start.
+--
+-- (snapshot_date, source) is the natural version. Keeping every snapshot
+-- rather than overwriting gives projection history for free, and lets a second
+-- source land beside ESPN with no migration.
+--
+-- Run this in your Supabase SQL editor.
+
+CREATE TABLE IF NOT EXISTS fantasy_projections (
+    id SERIAL PRIMARY KEY,
+    snapshot_date DATE NOT NULL,
+    source VARCHAR(30) NOT NULL,
+    season INTEGER NOT NULL,
+    -- nflverse gsis_id: the join key every other fantasy table uses.
+    player_id VARCHAR(20) NOT NULL,
+    player_name VARCHAR(80),
+    position VARCHAR(5),
+    team VARCHAR(10),
+    -- Stat line, season totals. Rushing and receiving touchdowns stay
+    -- separate: #81's sketch collapsed them into one `td`, but scoring.py
+    -- prices them independently and a TE-premium league prices receptions
+    -- against them, so collapsing here would lose information the board needs.
+    pass_yd NUMERIC,
+    pass_td NUMERIC,
+    ints NUMERIC,
+    rush_yd NUMERIC,
+    rush_td NUMERIC,
+    rec NUMERIC,
+    rec_yd NUMERIC,
+    rec_td NUMERIC,
+    fum NUMERIC,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (snapshot_date, source, player_id)
+);
+
+-- The read the board does: newest snapshot for a source and season.
+CREATE INDEX IF NOT EXISTS idx_fantasy_projections_snapshot
+    ON fantasy_projections(source, season, snapshot_date DESC);
+
+ALTER TABLE fantasy_projections ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Enable all operations for fantasy_projections"
+    ON fantasy_projections FOR ALL USING (true);

--- a/scripts/verify_tables.py
+++ b/scripts/verify_tables.py
@@ -10,7 +10,11 @@ import sys
 # Add the project root to the path
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from src.g_nfl.utils.database import MarketLinesDatabase, PoolSpreadsDatabase
+from src.g_nfl.utils.database import (
+    FantasyProjectionsDatabase,
+    MarketLinesDatabase,
+    PoolSpreadsDatabase,
+)
 
 
 def verify_tables():
@@ -42,9 +46,21 @@ def verify_tables():
         print(f"❌ pool_spreads table issue: {e}")
         pool_ok = False
 
+    # fantasy_projections table (#81) — created by hand from
+    # scripts/fantasy_projections_schema.sql, so this is the check that it was.
+    try:
+        proj_db = FantasyProjectionsDatabase()
+        latest = proj_db.latest_snapshot_date("espn", 2026)
+        print("✅ fantasy_projections table exists and is accessible")
+        print(f"   Latest espn 2026 snapshot: {latest or 'none ingested yet'}")
+        proj_ok = True
+    except Exception as e:
+        print(f"❌ fantasy_projections table issue: {e}")
+        proj_ok = False
+
     print()
 
-    if market_ok and pool_ok:
+    if market_ok and pool_ok and proj_ok:
         print("🎉 All tables verified successfully!")
         print("\n✅ Next steps:")
         print("1. Run 'python scripts/update_market_lines.py --season 2025 --week 1'")
@@ -53,6 +69,9 @@ def verify_tables():
     else:
         print("❌ Some tables have issues. Please check your Supabase setup.")
         print("\n💡 Make sure you've run the SQL from 'scripts/database_schema.sql'")
+        print(
+            "   and, for fantasy_projections, 'scripts/fantasy_projections_schema.sql'"
+        )
         return False
 
 

--- a/src/g_nfl/fantasy/ingest.py
+++ b/src/g_nfl/fantasy/ingest.py
@@ -1,0 +1,94 @@
+"""Push a dated snapshot of fantasy projections to Supabase (issue #81).
+
+    uv run python -m g_nfl.fantasy.ingest --season 2026
+
+Griffin runs this by hand. **The API never scrapes**, which buys three things
+worth protecting: a broken scraper leaves the last good snapshot serving, no
+scrape sits in the request path to blow a Render cold start, and staleness is
+visible in ``snapshot_date`` instead of silent.
+
+The table is created separately — run ``scripts/fantasy_projections_schema.sql``
+in the Supabase SQL editor first. This repo has no migration runner, and #81 is
+not the place to invent one.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+import polars as pl
+
+from g_nfl.fantasy.sources.espn import fetch_espn_projections
+from g_nfl.utils.database import FantasyProjectionsDatabase
+
+#: source name -> loader. One entry today; the schema is keyed on ``source`` so
+#: a second feed lands beside ESPN without a migration.
+SOURCES = {"espn": fetch_espn_projections}
+
+# Rows missing a gsis_id cannot be joined to anything downstream. The ESPN
+# loader already fails below a 95% match rate, so this only drops the tail.
+_KEY = "gsis_id"
+
+
+def to_rows(
+    stat_lines: pl.DataFrame, source: str, season: int, snapshot_date: date
+) -> list[dict]:
+    """Stat lines -> ``fantasy_projections`` rows, dropping unjoinable players."""
+    stats = list(FantasyProjectionsDatabase.STAT_COLUMNS)
+    return (
+        stat_lines.drop_nulls(_KEY)
+        .select(
+            pl.lit(snapshot_date.isoformat()).alias("snapshot_date"),
+            pl.lit(source).alias("source"),
+            pl.lit(season).alias("season"),
+            pl.col(_KEY).alias("player_id"),
+            "player_name",
+            "position",
+            "team",
+            *stats,
+        )
+        .to_dicts()  # hard boundary: supabase-py speaks dicts, not frames
+    )
+
+
+def ingest(
+    season: int,
+    source: str = "espn",
+    snapshot_date: date | None = None,
+    db: FantasyProjectionsDatabase | None = None,
+) -> int:
+    """Fetch one source and upsert it as today's snapshot. Returns rows written."""
+    if source not in SOURCES:
+        raise ValueError(f"Unknown source {source!r}; known: {', '.join(SOURCES)}")
+
+    stat_lines = SOURCES[source](season)
+    rows = to_rows(stat_lines, source, season, snapshot_date or date.today())
+    dropped = stat_lines.height - len(rows)
+    if dropped:
+        print(f"Dropped {dropped} row(s) with no gsis_id")
+
+    return (db or FantasyProjectionsDatabase()).save_snapshot(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Push a dated snapshot of fantasy projections to Supabase. "
+        "Run scripts/fantasy_projections_schema.sql once before the first use."
+    )
+    parser.add_argument("--season", type=int, required=True)
+    parser.add_argument("--source", default="espn", choices=sorted(SOURCES))
+    parser.add_argument(
+        "--date",
+        type=date.fromisoformat,
+        default=None,
+        help="Snapshot date (YYYY-MM-DD). Defaults to today.",
+    )
+    args = parser.parse_args()
+
+    written = ingest(args.season, args.source, args.date)
+    print(f"Wrote {written} rows for {args.source} {args.season}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/g_nfl/utils/database.py
+++ b/src/g_nfl/utils/database.py
@@ -575,3 +575,76 @@ class PoolSpreadsDatabase:
         except Exception as e:
             print(f"Error updating pool spread: {e}")
             return False
+
+
+class FantasyProjectionsDatabase:
+    """Dated snapshots of season-total fantasy stat lines (issue #81).
+
+    Written by ``g_nfl.fantasy.ingest``, which Griffin runs by hand. Nothing in
+    the request path scrapes, so a broken source degrades to a stale snapshot
+    instead of an error, and the caller can see how stale from ``snapshot_date``.
+    """
+
+    #: Stat columns, matching the ESPN source contract in ``fantasy.sources.espn``.
+    STAT_COLUMNS = (
+        "pass_yd",
+        "pass_td",
+        "ints",
+        "rush_yd",
+        "rush_td",
+        "rec",
+        "rec_yd",
+        "rec_td",
+        "fum",
+    )
+
+    def __init__(self):
+        self.client: Client = get_supabase()
+
+    def save_snapshot(self, rows: list[dict]) -> int:
+        """Upsert one snapshot's rows, keyed by (snapshot_date, source, player_id).
+
+        Upsert rather than insert so re-running an ingest the same day is a
+        no-op instead of a duplicate snapshot.
+        """
+        if not rows:
+            return 0
+        payload = [{**r, "updated_at": datetime.utcnow().isoformat()} for r in rows]
+        self.client.table("fantasy_projections").upsert(
+            payload, on_conflict="snapshot_date,source,player_id"
+        ).execute()
+        return len(payload)
+
+    def latest_snapshot_date(self, source: str, season: int) -> str | None:
+        """Newest ``snapshot_date`` for a source, or None if never ingested."""
+        result = (
+            self.client.table("fantasy_projections")
+            .select("snapshot_date")
+            .eq("source", source)
+            .eq("season", season)
+            .order("snapshot_date", desc=True)
+            .limit(1)
+            .execute()
+        )
+        return result.data[0]["snapshot_date"] if result.data else None
+
+    def get_snapshot(
+        self, source: str, season: int, snapshot_date: str | None = None
+    ) -> list[dict]:
+        """One snapshot's rows; the newest one when ``snapshot_date`` is None.
+
+        Returns an empty list when the source has never been ingested, which
+        the caller should treat as "fall back to a live fetch", not as an error.
+        """
+        snapshot_date = snapshot_date or self.latest_snapshot_date(source, season)
+        if snapshot_date is None:
+            return []
+        result = (
+            self.client.table("fantasy_projections")
+            .select("*")
+            .eq("source", source)
+            .eq("season", season)
+            .eq("snapshot_date", snapshot_date)
+            .execute()
+        )
+        return result.data

--- a/tests/test_fantasy_ingest.py
+++ b/tests/test_fantasy_ingest.py
@@ -1,0 +1,75 @@
+"""Snapshot ingest for fantasy projections (issue #81). Network- and DB-free."""
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from g_nfl.fantasy.ingest import SOURCES, ingest, to_rows
+
+
+class FakeDB:
+    """Stands in for FantasyProjectionsDatabase without a Supabase client."""
+
+    def __init__(self):
+        self.saved: list[dict] = []
+
+    def save_snapshot(self, rows: list[dict]) -> int:
+        self.saved = rows
+        return len(rows)
+
+
+def _stat_lines() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "gsis_id": ["00-0034796", None],
+            "espn_id": [3139477, 1],
+            "player_name": ["Lamar Jackson", "Nobody"],
+            "position": ["QB", "WR"],
+            "team": ["BAL", "SEA"],
+            "pass_yd": [3800.0, 0.0],
+            "pass_td": [30.0, 0.0],
+            "ints": [8.0, 0.0],
+            "rush_yd": [820.0, 0.0],
+            "rush_td": [5.0, 0.0],
+            "rec": [0.0, 40.0],
+            "rec_yd": [0.0, 500.0],
+            "rec_td": [0.0, 3.0],
+            "fum": [4.0, 1.0],
+        }
+    )
+
+
+def test_rows_carry_the_snapshot_key_and_drop_unjoinable_players():
+    rows = to_rows(_stat_lines(), "espn", 2026, date(2026, 8, 17))
+
+    assert len(rows) == 1  # the null gsis_id row is unjoinable downstream
+    row = rows[0]
+    assert row["snapshot_date"] == "2026-08-17"
+    assert row["source"] == "espn"
+    assert row["season"] == 2026
+    assert row["player_id"] == "00-0034796"
+    assert row["pass_yd"] == 3800.0
+    assert "espn_id" not in row  # source-specific id has no column
+
+
+def test_rushing_and_receiving_touchdowns_stay_separate():
+    """#81's sketch had one `td`; scoring.py prices the two independently."""
+    row = to_rows(_stat_lines(), "espn", 2026, date(2026, 8, 17))[0]
+    assert row["rush_td"] == 5.0
+    assert row["rec_td"] == 0.0
+
+
+def test_ingest_writes_through_to_the_db(monkeypatch):
+    monkeypatch.setitem(SOURCES, "fake", lambda season: _stat_lines())
+    db = FakeDB()
+
+    written = ingest(2026, "fake", date(2026, 8, 17), db=db)
+
+    assert written == 1
+    assert db.saved[0]["source"] == "fake"
+
+
+def test_an_unknown_source_fails_before_the_network():
+    with pytest.raises(ValueError, match="Unknown source"):
+        ingest(2026, "nope", db=FakeDB())


### PR DESCRIPTION
Part of #73. Its three blockers (#74, #75, #85) are all closed.

## What ships

- `scripts/fantasy_projections_schema.sql` — the table, unique on `(snapshot_date, source, player_id)`.
- `FantasyProjectionsDatabase` in `utils/database.py` — `save_snapshot`, `latest_snapshot_date`, `get_snapshot`.
- `g_nfl.fantasy.ingest` — the CLI, `make ingest-fantasy SEASON=2026`.
- `make verify-db` now checks the table and prints the latest snapshot date.
- 4 tests, network- and DB-free via a fake client. Suite is 266.

## Two deliberate deviations from the ticket's sketch

- **Rushing and receiving TDs stay separate** instead of one `td`. `scoring.py` prices them independently and a TE-premium league prices receptions against them; collapsing loses information the board needs.
- **`season` is on the row.** Without it a `snapshot_date` is ambiguous as soon as a second season is ingested.

## The manual step

Run `scripts/fantasy_projections_schema.sql` in the Supabase SQL editor before the first ingest. DDL cannot go through PostgREST, and this machine has only `SUPABASE_PUBLISHABLE_KEY` — no service key, no `DATABASE_URL` — so I could not create it from here. That matches how every other table in this repo was made.

Verified the client reaches Supabase and the table is the only thing missing:

```
client ok
APIError {'message': "Could not find the table 'public.fantasy_projections' in the schema cache", 'code': 'PGRST205'}
```

After you run the SQL, `make verify-db` should go green and `make ingest-fantasy SEASON=2026` writes the first snapshot. The ticket asks for the row count of that first real snapshot recorded on the issue — I'll add it once the table exists, or you can paste the CLI's output.

## Unrelated thing I noticed

`CUR_SEASON` in `src/g_nfl/utils/config.py` still reads 2025. The fantasy code hardcodes 2026 and so does the new Make default, so nothing here is wrong, but the constant will be wrong for pool work once the season starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)