### PR TITLE
feat: make bootstrap, plus Supabase Storage for the irreplaceable files (#96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,15 @@ Disposition for a throwaway script:
 ```bash
 uv sync                # Install all dependencies (core + dev + analysis groups)
 cp .env.example .env   # Then fill in Supabase keys (dashboard → Settings → API Keys)
+make bootstrap         # Fresh clone: warms the caches, pulls the source documents
 ```
+
+`make bootstrap` (#96) re-downloads `data/ml_cache` and `data/sleeper_cache`
+through the pipeline's own loaders — slow once, and it cannot go stale the way a
+synced cache can. It then runs `make pull-data`, which fetches the files that
+**cannot** be regenerated (the pool workbooks) from Supabase Storage. Everything
+else under `data/` rebuilds from code and is never synced. `make push-data`
+sends a new workbook the other way.
 
 **Python version**: `>=3.11` (3.13 supported). `nfl-data-py` was the blocker (pinned `numpy<2`/`pandas<2`); it has been replaced by `nflreadpy` (#23).
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev run api web deploy-prep clean lint format test jupyter streamlit train backtest market-ratings mlflow-ui update-context ingest-fantasy
+.PHONY: help install dev bootstrap push-data pull-data run api web deploy-prep clean lint format test jupyter streamlit train backtest market-ratings mlflow-ui update-context ingest-fantasy
 
 # Default target
 help:
@@ -7,6 +7,9 @@ help:
 	@echo "📦 Setup & Development:"
 	@echo "  install       Install dependencies with uv"
 	@echo "  dev           Install dev dependencies and setup pre-commit"
+	@echo "  bootstrap     Fresh clone -> working repo (warms caches, pulls data)"
+	@echo "  push-data     Upload irreplaceable source documents to Supabase"
+	@echo "  pull-data     Fetch them back (ARGS=--force to overwrite newer local)"
 	@echo "  run           Run the fantasy draft board (Streamlit) locally"
 	@echo "  api           Run the FastAPI backend locally"
 	@echo "  web           Run the React frontend dev server"
@@ -43,6 +46,18 @@ install:
 dev: install
 	@echo "🛠️  Setting up development environment..."
 	uv run pre-commit install || echo "Pre-commit not configured"
+
+bootstrap: install
+	@echo "🥾 Bootstrapping a fresh clone (slow: warms ~163M of nflverse cache)..."
+	uv run python scripts/bootstrap.py $(ARGS)
+
+push-data:
+	@echo "☁️  Uploading source documents to Supabase Storage..."
+	uv run python scripts/sync_data.py push $(ARGS)
+
+pull-data:
+	@echo "⬇️  Fetching source documents from Supabase Storage..."
+	uv run python scripts/sync_data.py pull $(ARGS)
 
 run:
 	@echo "🏈 Running the fantasy draft board..."

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Take a fresh clone to a working repo (issue #96).
+
+    make bootstrap
+
+Warms the caches by calling the loaders the pipeline itself calls, then pulls
+the handful of files that cannot be regenerated. Slow once, correct always: a
+synced cache can go stale silently, a regenerated one cannot.
+
+``uv sync`` is the Make target's job, not this script's — by the time Python is
+running, the environment already exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[1] / "src"))
+
+from g_nfl.ml.data import DEFAULT_CACHE_DIR, load_pbp, load_schedule  # noqa: E402
+from g_nfl.sleeper.client import KNOWN_LEAGUES, SleeperClient  # noqa: E402
+from g_nfl.utils.storage import pull_data  # noqa: E402
+
+# What `make train` and the backtest run on. Play-by-play is ~10M a season, so
+# this is the slow step and the one worth being explicit about.
+DEFAULT_SEASONS = [2018, 2019, 2021, 2022, 2023, 2024, 2025]
+
+
+def warm_nflverse(seasons: list[int], refresh: bool) -> None:
+    print(f"→ nflverse cache: {len(seasons)} seasons into {DEFAULT_CACHE_DIR}")
+    for season in seasons:
+        load_schedule([season], refresh=refresh)
+        load_pbp([season], refresh=refresh)
+        print(f"  {season} ok")
+
+
+def warm_sleeper() -> None:
+    print("→ Sleeper cache: players blob + known leagues")
+    client = SleeperClient()
+    client.players()  # ~5MB, the expensive one
+    for name, league_id in KNOWN_LEAGUES.items():
+        client.league(league_id)
+        print(f"  {name} ok")
+
+
+def fetch_source_documents() -> None:
+    print("→ Source documents from Supabase Storage")
+    try:
+        result = pull_data()
+    except Exception as e:  # noqa: BLE001 — a fresh clone may have no keys yet
+        print(f"  skipped: {e}")
+        print("  (fix the bucket or the .env keys, then run `make pull-data`)")
+        return
+    print(f"  {result.summary()}")
+    for key in result.refused:
+        print(f"  refused {key}: local file is newer than the remote copy")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bootstrap a fresh clone.")
+    parser.add_argument("--seasons", type=int, nargs="+", default=DEFAULT_SEASONS)
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Refetch cached seasons. Do this for the current season in-year, "
+        "since its play-by-play grows every week.",
+    )
+    parser.add_argument(
+        "--skip-nflverse",
+        action="store_true",
+        help="Skip the slow step when you only want the caches you are missing.",
+    )
+    args = parser.parse_args()
+
+    if args.skip_nflverse:
+        print("→ nflverse cache: skipped")
+    else:
+        warm_nflverse(args.seasons, args.refresh)
+    warm_sleeper()
+    fetch_source_documents()
+
+    print("\nDone. Try:")
+    print("  uv run python -m g_nfl.fantasy.draft_board --preset ppr_12")
+    print("  make run")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_data.py
+++ b/scripts/sync_data.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Push or pull the source documents that cannot be regenerated (issue #96).
+
+    make push-data          # local -> Supabase Storage
+    make pull-data          # Supabase Storage -> local
+    make pull-data ARGS=--force
+
+The bucket has to exist first. Create it once in the Supabase dashboard,
+private, named as ``g_nfl.utils.storage.BUCKET`` — the publishable key cannot
+create buckets and neither laptop carries the service key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[1] / "src"))
+
+from g_nfl.utils.storage import (  # noqa: E402
+    BUCKET,
+    BucketMissing,
+    pull_data,
+    push_data,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("direction", choices=["push", "pull"])
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Pull only: overwrite a local file that is newer than the remote copy.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report what would move, move nothing."
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.direction == "push":
+            result = push_data(dry_run=args.dry_run)
+            for key in result.uploaded:
+                print(f"  {'would upload' if args.dry_run else 'uploaded'} {key}")
+        else:
+            result = pull_data(force=args.force, dry_run=args.dry_run)
+            for key in result.downloaded:
+                print(f"  {'would download' if args.dry_run else 'downloaded'} {key}")
+            for key in result.refused:
+                print(f"  refused {key}: local file is newer (--force to overwrite)")
+    except BucketMissing as e:
+        sys.exit(str(e))
+
+    print(f"{BUCKET}: {result.summary()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/g_nfl/utils/storage.py
+++ b/src/g_nfl/utils/storage.py
@@ -1,0 +1,164 @@
+"""Supabase Storage for the files that cannot be regenerated (issue #96).
+
+Almost everything under ``data/`` rebuilds from code: 163M of nflverse parquet
+re-downloads, the Sleeper cache re-fetches, board CSVs take 30 seconds. The
+exception is the pool workbooks, which came out of Griffin's inbox and exist
+nowhere else. Those are what this syncs, and #56 wants more of them.
+
+**Why Supabase and not S3.** Supabase is already provisioned, already in
+``.env``, and already holds the tables these workbooks produced. S3 would mean
+a new account, IAM keys on two laptops and a fetch layer, to move 452K. S3
+earns its place when large point-in-time scrapes appear (paywalled PFF pulls,
+historical odds snapshots) — Supabase Storage gets expensive per GB first.
+
+**Idempotent in both directions.** Uploads skip files whose size already
+matches, and downloads refuse to clobber a local file that is newer than the
+remote copy unless told to. Losing an irreplaceable workbook to a careless
+sync would defeat the point of syncing it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .supabase_client import get_supabase
+
+#: Private bucket. Create it once in the Supabase dashboard: the publishable
+#: key cannot create buckets, and this repo has no service key on either laptop.
+BUCKET = "source-documents"
+
+# repo root: src/g_nfl/utils/storage.py -> utils -> g_nfl -> src -> root
+_ROOT = Path(__file__).parents[3]
+
+#: Local directories whose contents are irreplaceable, and the glob that
+#: catches them. Keyed by the prefix used inside the bucket.
+SOURCE_DOCUMENTS: dict[str, tuple[Path, str]] = {
+    "pool": (_ROOT / "data" / "pool", "*.xlsx"),
+}
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """What a push or pull did, so the caller can print it honestly."""
+
+    uploaded: tuple[str, ...] = ()
+    downloaded: tuple[str, ...] = ()
+    skipped: tuple[str, ...] = ()
+    refused: tuple[str, ...] = ()
+
+    def summary(self) -> str:
+        parts = [
+            f"{len(self.uploaded)} uploaded",
+            f"{len(self.downloaded)} downloaded",
+            f"{len(self.skipped)} unchanged",
+        ]
+        if self.refused:
+            parts.append(f"{len(self.refused)} refused (local file is newer)")
+        return ", ".join(parts)
+
+
+class BucketMissing(RuntimeError):
+    """The bucket has not been created yet, and listing it lies about that."""
+
+
+def _bucket(client=None):
+    storage = (client or get_supabase()).storage
+    # `from_(...).list()` on a bucket that does not exist returns [] rather than
+    # raising, which would turn `make pull-data` into a silent no-op on a fresh
+    # clone — the one moment it has to work. get_bucket 404s honestly.
+    get_bucket = getattr(storage, "get_bucket", None)
+    if get_bucket is not None:
+        try:
+            get_bucket(BUCKET)
+        except Exception as e:  # noqa: BLE001 — storage errors are not typed usefully
+            raise BucketMissing(
+                f"Supabase Storage bucket {BUCKET!r} not found ({e}). Create it once "
+                "in the dashboard (Storage → New bucket, private). The publishable "
+                "key cannot create buckets."
+            ) from e
+    return storage.from_(BUCKET)
+
+
+def _remote_index(bucket, prefix: str) -> dict[str, dict]:
+    """``{name: object}`` for one prefix. An empty prefix lists nothing, not an error."""
+    return {obj["name"]: obj for obj in bucket.list(prefix)}
+
+
+def _remote_size(obj: dict) -> int | None:
+    return (obj.get("metadata") or {}).get("size")
+
+
+def _remote_modified(obj: dict) -> datetime | None:
+    stamp = obj.get("updated_at") or obj.get("created_at")
+    if not stamp:
+        return None
+    return datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+
+
+def push_data(client=None, dry_run: bool = False) -> SyncResult:
+    """Upload local source documents, skipping ones already there at the same size.
+
+    Size rather than a hash: Supabase's listing gives size for free, and these
+    are append-only workbooks — a changed workbook changes length. A hash would
+    mean downloading every remote file to compare, which is the cost this is
+    trying to avoid.
+    """
+    bucket = _bucket(client)
+    uploaded, skipped = [], []
+
+    for prefix, (directory, pattern) in SOURCE_DOCUMENTS.items():
+        if not directory.exists():
+            continue
+        remote = _remote_index(bucket, prefix)
+        for path in sorted(directory.glob(pattern)):
+            key = f"{prefix}/{path.name}"
+            existing = remote.get(path.name)
+            if existing and _remote_size(existing) == path.stat().st_size:
+                skipped.append(key)
+                continue
+            if not dry_run:
+                bucket.upload(
+                    key,
+                    path.read_bytes(),
+                    {"upsert": "true", "content-type": "application/octet-stream"},
+                )
+            uploaded.append(key)
+
+    return SyncResult(uploaded=tuple(uploaded), skipped=tuple(skipped))
+
+
+def pull_data(client=None, force: bool = False, dry_run: bool = False) -> SyncResult:
+    """Fetch source documents into their local directories.
+
+    Refuses to overwrite a local file modified more recently than the remote
+    object unless ``force``. That case means the two laptops both edited a
+    workbook, and silently picking one is how the irreplaceable copy is lost.
+    """
+    bucket = _bucket(client)
+    downloaded, skipped, refused = [], [], []
+
+    for prefix, (directory, _) in SOURCE_DOCUMENTS.items():
+        for name, obj in _remote_index(bucket, prefix).items():
+            key = f"{prefix}/{name}"
+            local = directory / name
+
+            if local.exists():
+                if _remote_size(obj) == local.stat().st_size:
+                    skipped.append(key)
+                    continue
+                remote_time = _remote_modified(obj)
+                local_time = datetime.fromtimestamp(local.stat().st_mtime, UTC)
+                if not force and remote_time and local_time > remote_time:
+                    refused.append(key)
+                    continue
+
+            if not dry_run:
+                directory.mkdir(parents=True, exist_ok=True)
+                local.write_bytes(bucket.download(key))
+            downloaded.append(key)
+
+    return SyncResult(
+        downloaded=tuple(downloaded), skipped=tuple(skipped), refused=tuple(refused)
+    )

--- a/tests/test_utils_storage.py
+++ b/tests/test_utils_storage.py
@@ -1,0 +1,124 @@
+"""Source-document sync (issue #96). No network, no Supabase."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from g_nfl.utils import storage
+
+
+class FakeBucket:
+    """The three storage methods the sync uses, over an in-memory dict."""
+
+    def __init__(self, objects: dict[str, tuple[bytes, datetime]] | None = None):
+        self.objects = objects or {}
+        self.uploads: list[str] = []
+
+    def list(self, prefix: str):
+        out = []
+        for key, (body, modified) in self.objects.items():
+            head, _, name = key.partition("/")
+            if head == prefix:
+                out.append(
+                    {
+                        "name": name,
+                        "updated_at": modified.isoformat(),
+                        "metadata": {"size": len(body)},
+                    }
+                )
+        return out
+
+    def upload(self, key: str, body: bytes, options: dict):
+        self.uploads.append(key)
+        self.objects[key] = (body, datetime.now(UTC))
+
+    def download(self, key: str) -> bytes:
+        return self.objects[key][0]
+
+
+class FakeClient:
+    def __init__(self, bucket: FakeBucket):
+        self._bucket = bucket
+        self.storage = self
+
+    def from_(self, name: str):
+        return self._bucket
+
+
+@pytest.fixture
+def pool_dir(tmp_path, monkeypatch):
+    """Point SOURCE_DOCUMENTS at a temp directory instead of data/pool."""
+    directory = tmp_path / "pool"
+    directory.mkdir()
+    monkeypatch.setattr(
+        storage, "SOURCE_DOCUMENTS", {"pool": (directory, "*.xlsx")}, raising=True
+    )
+    return directory
+
+
+def test_push_uploads_new_files_and_skips_matching_ones(pool_dir):
+    (pool_dir / "standings_2025.xlsx").write_bytes(b"workbook")
+    (pool_dir / "standings_2024.xlsx").write_bytes(b"new one")
+    bucket = FakeBucket({"pool/standings_2025.xlsx": (b"workbook", datetime.now(UTC))})
+
+    result = storage.push_data(client=FakeClient(bucket))
+
+    assert result.uploaded == ("pool/standings_2024.xlsx",)
+    assert result.skipped == ("pool/standings_2025.xlsx",)
+    assert bucket.uploads == ["pool/standings_2024.xlsx"]
+
+
+def test_push_reuploads_when_the_size_changed(pool_dir):
+    (pool_dir / "standings_2025.xlsx").write_bytes(b"workbook, now longer")
+    bucket = FakeBucket({"pool/standings_2025.xlsx": (b"workbook", datetime.now(UTC))})
+
+    assert storage.push_data(client=FakeClient(bucket)).uploaded == (
+        "pool/standings_2025.xlsx",
+    )
+
+
+def test_pull_fetches_files_the_clone_does_not_have(pool_dir):
+    bucket = FakeBucket({"pool/standings_2025.xlsx": (b"workbook", datetime.now(UTC))})
+
+    result = storage.pull_data(client=FakeClient(bucket))
+
+    assert result.downloaded == ("pool/standings_2025.xlsx",)
+    assert (pool_dir / "standings_2025.xlsx").read_bytes() == b"workbook"
+
+
+def test_pull_refuses_to_clobber_a_newer_local_file(pool_dir):
+    """The case that would lose an irreplaceable workbook: both laptops edited."""
+    local = pool_dir / "standings_2025.xlsx"
+    local.write_bytes(b"edited here, longer than remote")
+    stale = datetime.now(UTC) - timedelta(days=2)
+    bucket = FakeBucket({"pool/standings_2025.xlsx": (b"older", stale)})
+
+    result = storage.pull_data(client=FakeClient(bucket))
+
+    assert result.refused == ("pool/standings_2025.xlsx",)
+    assert local.read_bytes() == b"edited here, longer than remote"
+
+    forced = storage.pull_data(client=FakeClient(bucket), force=True)
+    assert forced.downloaded == ("pool/standings_2025.xlsx",)
+    assert local.read_bytes() == b"older"
+
+
+def test_dry_run_moves_nothing(pool_dir):
+    (pool_dir / "standings_2024.xlsx").write_bytes(b"new one")
+    bucket = FakeBucket()
+
+    result = storage.push_data(client=FakeClient(bucket), dry_run=True)
+
+    assert result.uploaded == ("pool/standings_2024.xlsx",)
+    assert bucket.uploads == []
+
+
+def test_a_missing_bucket_is_an_error_not_an_empty_sync(pool_dir):
+    """`list()` returns [] for a bucket that does not exist, so check first."""
+
+    class NoBucketClient(FakeClient):
+        def get_bucket(self, name):
+            raise RuntimeError("Bucket not found")
+
+    with pytest.raises(storage.BucketMissing, match="not found"):
+        storage.pull_data(client=NoBucketClient(FakeBucket()))


### PR DESCRIPTION
Addresses #96. Both parts.

## Part 1 — source documents

- `src/g_nfl/utils/storage.py`: `push_data` / `pull_data` over a private bucket, reusing the existing client singleton.
- `make push-data`, `make pull-data` (`ARGS=--force`, `ARGS=--dry-run`).
- Idempotent both ways. Push skips files already there at the same size (size, not hash: the listing gives size for free, and a hash means downloading every remote file to compare, which is the cost being avoided). Pull refuses to clobber a local file newer than the remote copy unless `--force`.

**The open question in the ticket, answered as specified: private.** Which surfaces a decision that is yours.

## Part 2 — `make bootstrap`

`uv sync` → warm `ml_cache` and `sleeper_cache` through the pipeline's own loaders → `pull-data` → print what it did and what it skipped. `--skip-nflverse` skips the slow leg.

Verified end to end with the bucket absent, and it degrades to a warning instead of failing the bootstrap:

```
→ nflverse cache: skipped
→ Sleeper cache: players blob + known leagues
  dudes_rock ok
  money_manziel ok
→ Source documents from Supabase Storage
  skipped: Supabase Storage bucket 'source-documents' not found ...
```

## One trap

`from_(bucket).list()` returns `[]` for a bucket that does not exist rather than raising, so `make pull-data` would have been a silent no-op on a fresh clone — the one moment it has to work. `_bucket()` now calls `get_bucket` first, which 404s honestly. There is a test for it.

## What you need to do, and the decision in it

Create the bucket: **Storage → New bucket → `source-documents`, private.** The publishable key cannot create buckets (403, RLS), and neither laptop has a service key.

Then the decision that follows from "private": a private bucket is not readable by the publishable key either, so pick one —

1. **Add storage policies** on the bucket allowing read and write for `anon`. Keeps the key situation as it is; the bucket is private to the internet but open to anyone holding the publishable key.
2. **Put the service key in `.env`** on both laptops (`SUPABASE_SECRET_KEY`, which `supabase_client.py` already checks for last). Tighter, and it is one more secret to carry.

I'd take 2 — the publishable key is in the deployed frontend's reach, and these are the files that cannot be recreated.

`make push-data` then uploads the 2025 workbook. Dry run against the real project confirms it is the one file queued:

```
would upload pool/standings_2025.xlsx
```

## Verification

272 tests (6 new, all network-free via a fake bucket). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)